### PR TITLE
release: v0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 /tests
 .idea/
 cobertura.xml
+internal_docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tasklet"
-version = "0.2.12"
+version = "0.3.0"
 authors = ["Stavros Grigoriou <unix121@protonmail.com>"]
 edition = "2021"
 rust-version = "1.90.0"
@@ -14,10 +14,16 @@ keywords = ["cron", "scheduling", "tasks", "tasklet", "async"]
 cron = "0.15.0"
 chrono = "0.4.42"
 log = "0.4.29"
-tokio = { version = "1.48.0", features = ["full"] }
+# Only the runtime pieces the library actually uses: spawning tasks, channels /
+# Notify, timers and the `select!`/`pin!` macros. Downstream crates can enable
+# more features themselves.
+tokio = { version = "1.48.0", features = ["rt", "sync", "time", "macros"] }
 futures = "0.3.31"
 thiserror = "2.0.17"
 
 [dev-dependencies]
 simple_logger = "5.1.0"
 tokio-test = "0.4.4"
+# Examples and tests need the macros and a multi-thread runtime on top of the
+# library's minimal feature set.
+tokio = { version = "1.48.0", features = ["rt-multi-thread", "macros"] }

--- a/README.md
+++ b/README.md
@@ -34,12 +34,18 @@ In your `Cargo.toml` add:
 
 ```
 [dependencies]
-tasklet = "0.2.12"
+tasklet = "0.3.0"
 ```
+
+> **Upgrading from 0.2.x?** See the [migration notes](#migrating-from-02x-to-030) below —
+> task steps are now `async`.
 
 ## Example
 
 Find more examples in the [examples](/examples) folder.
+
+Task steps are **asynchronous**: every step is a closure that returns a future, so it can
+`.await` real work (I/O, timers, network calls) without blocking the runtime.
 
 ```rust
 use log::info;
@@ -68,18 +74,22 @@ async fn main() {
         TaskBuilder::new(chrono::Local)
             .every("1 * * * * * *")
             .description("A simple task")
-            .add_step("Step 1", || {
+            .add_step("Step 1", || async {
                 info!("Hello from step 1");
                 Ok(Success) // Let the scheduler know this step was a success.
             })
             .add_step("Step 2", move || {
-                if exec_count % 2 == 0 {
-                    exec_count += 1;
-                    Err(Error) // Indicate that this step was a fail.
-                } else {
-                    info!("Hello from step 2");
-                    exec_count += 1;
-                    Ok(Success) // Indicate that this step was a success.
+                // Snapshot per-run state, then move it into the async block so the
+                // returned future is `'static`.
+                let count = exec_count;
+                exec_count += 1;
+                async move {
+                    if count % 2 == 0 {
+                        Err(Error) // Indicate that this step was a fail.
+                    } else {
+                        info!("Hello from step 2");
+                        Ok(Success) // Indicate that this step was a success.
+                    }
                 }
             })
             .build(),
@@ -89,6 +99,51 @@ async fn main() {
     scheduler.run().await;
 }
 ```
+
+## Graceful shutdown
+
+`scheduler.run()` normally loops forever. To stop it cleanly, grab a
+`SchedulerHandle` with `scheduler.handle()` *before* running and call `shutdown()`
+from anywhere — the current round finishes, the tasks are drained and `run()` returns:
+
+```rust,no_run
+# use tasklet::TaskScheduler;
+# #[tokio::main]
+# async fn main() {
+let mut scheduler = TaskScheduler::default(chrono::Utc);
+let handle = scheduler.handle();
+
+// Stop on Ctrl-C.
+tokio::spawn(async move {
+    tokio::signal::ctrl_c().await.ok();
+    handle.shutdown();
+});
+
+scheduler.run().await; // returns once shutdown is requested
+# }
+```
+
+You can also drive the shutdown with any future via `scheduler.run_until(future)` — for
+example a timer or an OS signal.
+
+## Migrating from 0.2.x to 0.3.0
+
+- **Steps are now async.** A step closure must return a future. Wrap synchronous bodies
+  in an `async` block:
+
+  ```rust,ignore
+  // 0.2.x
+  .add_step("Step", || Ok(Success))
+  // 0.3.0
+  .add_step("Step", || async { Ok(Success) })
+  ```
+
+  For state that changes between runs, snapshot it in the (`FnMut`) closure and `move` the
+  snapshot into the `async move` block so the future stays `'static`.
+- **`TaskGenerator::new` now returns a `Result`.** It no longer panics on an invalid cron
+  expression — call `?`/`.unwrap()` on the result.
+- **`TaskScheduler::run` can now stop.** It returns when a shutdown is requested through a
+  `SchedulerHandle`; if you never request one, behaviour is unchanged (runs forever).
 
 ## Author
 

--- a/examples/force_remove_example.rs
+++ b/examples/force_remove_example.rs
@@ -24,22 +24,26 @@ async fn main() {
         TaskBuilder::new(chrono::Local)
             .every("0,5,10,15,20,25,30,35,40,45,50,55 * * * * * *")
             .description("A simple task")
-            .add_step("Step 1", || {
+            .add_step("Step 1", || async {
                 info!("Hello from step 1");
                 Ok(Success) // Let the scheduler know this step was a success.
             })
             .add_step("Step 2", move || {
-                if exec_count == 10 {
-                    info!("Force deleting!");
-                    return Err(ErrorDelete);
-                }
-                if exec_count % 2 == 0 {
-                    exec_count += 1;
-                    Err(Error) // Indicate that this step was a fail.
-                } else {
-                    info!("Hello from step 2");
-                    exec_count += 1;
-                    Ok(Success) // Indicate that this step was a success.
+                // Snapshot the counter for this run, then advance it so the returned
+                // future can own its state and stay `'static`.
+                let count = exec_count;
+                exec_count += 1;
+                async move {
+                    if count == 10 {
+                        info!("Force deleting!");
+                        return Err(ErrorDelete);
+                    }
+                    if count % 2 == 0 {
+                        Err(Error) // Indicate that this step was a fail.
+                    } else {
+                        info!("Hello from step 2");
+                        Ok(Success) // Indicate that this step was a success.
+                    }
                 }
             })
             .build(),

--- a/examples/generator_example.rs
+++ b/examples/generator_example.rs
@@ -15,27 +15,30 @@ async fn main() {
     let mut scheduler = TaskScheduler::default(Utc);
     // Add a new `TaskGenerator` instance that generates a task
     // that leaves for 2 seconds, at the start of each minute.
-    scheduler.set_task_gen(TaskGenerator::new("1 * * * * * *", Utc, || {
-        // Run at second "1" of every minute.
+    scheduler.set_task_gen(
+        TaskGenerator::new("1 * * * * * *", Utc, || {
+            // Run at second "1" of every minute.
 
-        // Create the task that will execute 2 total times.
-        // Return the task for the execution queue.
-        Some(
-            TaskBuilder::new(Utc)
-                .every("0,10,20,30,40,50 * * * * * *")
-                .description("Generated task")
-                .repeat(2)
-                .add_step_default(|| {
-                    info!("[Step 1] This is a generated task!");
-                    Ok(Success)
-                })
-                .add_step_default(|| {
-                    info!("[Step 2] This is generated task!");
-                    Ok(Success)
-                })
-                .build(),
-        )
-    }));
+            // Create the task that will execute 2 total times.
+            // Return the task for the execution queue.
+            Some(
+                TaskBuilder::new(Utc)
+                    .every("0,10,20,30,40,50 * * * * * *")
+                    .description("Generated task")
+                    .repeat(2)
+                    .add_step_default(|| async {
+                        info!("[Step 1] This is a generated task!");
+                        Ok(Success)
+                    })
+                    .add_step_default(|| async {
+                        info!("[Step 2] This is generated task!");
+                        Ok(Success)
+                    })
+                    .build(),
+            )
+        })
+        .unwrap(),
+    );
 
     // Execute the scheduler.
     scheduler.run().await;

--- a/examples/one_task_example.rs
+++ b/examples/one_task_example.rs
@@ -24,18 +24,22 @@ async fn main() {
         TaskBuilder::new(chrono::Local)
             .every("1 * * * * * *")
             .description("A simple task")
-            .add_step_default(|| {
+            .add_step_default(|| async {
                 info!("Hello from step 1");
                 Ok(Success) // Let the scheduler know this step was a success.
             })
             .add_step_default(move || {
-                if exec_count % 2 == 0 {
-                    exec_count += 1;
-                    return Err(Error); // Indicate that this step was a fail.
-                }
-                info!("Hello from step 2");
+                // Snapshot the counter for this run, then advance it so the returned
+                // future can own its state and stay `'static`.
+                let count = exec_count;
                 exec_count += 1;
-                Ok(Success) // Indicate that this step was a success.
+                async move {
+                    if count % 2 == 0 {
+                        return Err(Error); // Indicate that this step was a fail.
+                    }
+                    info!("Hello from step 2");
+                    Ok(Success) // Indicate that this step was a success.
+                }
             })
             .build(),
     );

--- a/examples/read_me_example.rs
+++ b/examples/read_me_example.rs
@@ -24,18 +24,22 @@ async fn main() {
         TaskBuilder::new(chrono::Local)
             .every("1 * * * * * *")
             .description("A simple task")
-            .add_step("Step 1", || {
+            .add_step("Step 1", || async {
                 info!("Hello from step 1");
                 Ok(Success) // Let the scheduler know this step was a success.
             })
             .add_step("Step 2", move || {
-                if exec_count % 2 == 0 {
-                    exec_count += 1;
-                    Err(Error) // Indicate that this step was a fail.
-                } else {
-                    info!("Hello from step 2");
-                    exec_count += 1;
-                    Ok(Success) // Indicate that this step was a success.
+                // Snapshot the counter for this run, then advance it. The async block
+                // owns the snapshot so the returned future stays `'static`.
+                let count = exec_count;
+                exec_count += 1;
+                async move {
+                    if count % 2 == 0 {
+                        Err(Error) // Indicate that this step was a fail.
+                    } else {
+                        info!("Hello from step 2");
+                        Ok(Success) // Indicate that this step was a success.
+                    }
                 }
             })
             .build(),

--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -26,9 +26,12 @@ async fn main() {
                 .description("Just some task")
                 .repeat(5)
                 .add_step_default(move || {
-                    count = count - 1;
-                    info!("I have {} more executions left!", count);
-                    Ok(Success)
+                    count -= 1;
+                    let remaining = count;
+                    async move {
+                        info!("I have {} more executions left!", remaining);
+                        Ok(Success)
+                    }
                 })
                 .build(),
         )
@@ -37,7 +40,7 @@ async fn main() {
             TaskBuilder::new(chrono::Utc)
                 .every("1, 10 , 20 * * * * * *")
                 .description("Just another task")
-                .add_step_default(|| {
+                .add_step_default(|| async {
                     info!("I will run forever!");
                     Ok(Success)
                 })

--- a/examples/task_builder_example.rs
+++ b/examples/task_builder_example.rs
@@ -19,8 +19,8 @@ async fn main() {
             .every("* * * * * *")
             .description("Some description")
             .repeat(5)
-            .add_step("First step", || Ok(Success))
-            .add_step("Second step", || Ok(Success))
+            .add_step("First step", || async { Ok(Success) })
+            .add_step("Second step", || async { Ok(Success) })
             .build(),
     );
 

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -122,11 +122,14 @@ where
     /// ```rust
     /// # use tasklet::task::TaskStepStatusErr::Error;
     /// # use tasklet::TaskBuilder;
-    /// let _ = TaskBuilder::new(chrono::Utc).add_step("A step that fails.", || Err(Error));
+    /// let _ = TaskBuilder::new(chrono::Utc).add_step("A step that fails.", || async { Err(Error) });
     /// ```
-    pub fn add_step<F>(mut self, description: &str, function: F) -> TaskBuilder<T>
+    pub fn add_step<F, Fut>(mut self, description: &str, function: F) -> TaskBuilder<T>
     where
-        F: (FnMut() -> Result<TaskStepStatusOk, TaskStepStatusErr>) + Send + 'static,
+        F: (FnMut() -> Fut) + Send + 'static,
+        Fut: std::future::Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>>
+            + Send
+            + 'static,
     {
         self.steps.push(TaskStep::new(description, function));
         self
@@ -141,11 +144,14 @@ where
     /// ```
     /// # use tasklet::task::TaskStepStatusOk::Success;
     /// use tasklet::TaskBuilder;
-    /// let _ = TaskBuilder::new(chrono::Local).add_step_default(|| Ok(Success));
+    /// let _ = TaskBuilder::new(chrono::Local).add_step_default(|| async { Ok(Success) });
     /// ```
-    pub fn add_step_default<F>(mut self, function: F) -> TaskBuilder<T>
+    pub fn add_step_default<F, Fut>(mut self, function: F) -> TaskBuilder<T>
     where
-        F: (FnMut() -> Result<TaskStepStatusOk, TaskStepStatusErr>) + 'static + Send,
+        F: (FnMut() -> Fut) + 'static + Send,
+        Fut: std::future::Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>>
+            + Send
+            + 'static,
     {
         self.steps.push(TaskStep::default(function));
         self
@@ -261,7 +267,7 @@ mod test {
     /// Test the normal functionality of the add_step() function of the `TaskBuilder`.
     #[test]
     pub fn test_task_builder_add_step() {
-        let builder = TaskBuilder::new(chrono::Utc).add_step_default(|| Ok(Success));
+        let builder = TaskBuilder::new(chrono::Utc).add_step_default(|| async { Ok(Success) });
         assert_eq!(builder.timezone, chrono::Utc);
         assert_eq!(builder.steps.len(), 1);
     }
@@ -273,7 +279,7 @@ mod test {
             .every("* * * * * * *")
             .repeat(5)
             .description("Some description")
-            .add_step("Step 1", || Ok(Success))
+            .add_step("Step 1", || async { Ok(Success) })
             .build()
             .unwrap();
         assert_some!(task.repeats);
@@ -287,7 +293,7 @@ mod test {
     pub fn test_task_builder_build_default() {
         let task = TaskBuilder::new(chrono::Utc)
             .repeat(5)
-            .add_step("Step 1", || Ok(Success))
+            .add_step("Step 1", || async { Ok(Success) })
             .build()
             .unwrap();
         assert_some!(task.repeats);

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,6 +1,6 @@
 extern crate chrono;
 extern crate cron;
-use crate::errors::TaskResult;
+use crate::errors::{TaskError, TaskResult};
 use crate::scheduler_log;
 use crate::task::Task;
 use chrono::prelude::*;
@@ -38,26 +38,44 @@ where
     /// * function      - The discovery function.
     /// * timezone      - The generator's timezone.
     ///
+    /// # Errors
+    ///
+    /// Returns [`TaskError::InvalidCronExpression`] if `expression` is not a valid cron
+    /// expression, or if it yields no upcoming execution time.
+    ///
     /// # Examples
     ///
     /// ```
     /// # use tasklet::{TaskGenerator, Task};
     /// // Create a `TaskGenerator` instance.
     /// // It will be executed at the first second of each minute.
-    /// let _task_gen = TaskGenerator::new("1 * * * * * *", chrono::Local, || Some(Task::new("* * * * * * *", None, None, chrono::Local)));
+    /// let _task_gen = TaskGenerator::new("1 * * * * * *", chrono::Local, || Some(Task::new("* * * * * * *", None, None, chrono::Local))).unwrap();
     /// ```
-    pub fn new<F>(expression: &str, timezone: T, function: F) -> TaskGenerator<T>
+    pub fn new<F>(expression: &str, timezone: T, function: F) -> TaskResult<TaskGenerator<T>>
     where
         F: (FnMut() -> Option<TaskResult<Task<T>>>) + 'static,
     {
-        let schedule: Schedule = expression.parse().unwrap();
+        // Parse the cron expression a single time and surface any error.
+        let schedule: Schedule = expression.parse().map_err(|e| {
+            TaskError::InvalidCronExpression(format!(
+                "Invalid cron expression '{}': {}",
+                expression, e
+            ))
+        })?;
 
-        TaskGenerator {
+        let next_exec = schedule.upcoming(timezone.clone()).next().ok_or_else(|| {
+            TaskError::InvalidCronExpression(format!(
+                "Cron expression '{}' has no upcoming execution",
+                expression
+            ))
+        })?;
+
+        Ok(TaskGenerator {
             discovery_function: Box::new(function),
-            schedule: expression.parse().unwrap(),
-            timezone: timezone.clone(),
-            next_exec: schedule.upcoming(timezone).next().unwrap(),
-        }
+            schedule,
+            timezone,
+            next_exec,
+        })
     }
 
     /// Run the discovery function and reschedule the generation function.
@@ -92,7 +110,8 @@ mod test {
         // Create a task generation instance.
         let mut task_gen = TaskGenerator::new("* * * * * * *", Local, || {
             Some(Task::new("* * * * * * *", None, Some(1), Local))
-        });
+        })
+        .unwrap();
         assert!(task_gen.run().is_some());
     }
 
@@ -102,8 +121,19 @@ mod test {
     #[test]
     fn test_task_generation_without_result() {
         // Create a task generation instance.
-        let mut task_gen = TaskGenerator::new("* * * * * * *", Local, || None);
+        let mut task_gen = TaskGenerator::new("* * * * * * *", Local, || None).unwrap();
         assert!(task_gen.run().is_none());
+    }
+
+    /// An invalid cron expression must yield an error instead of panicking.
+    #[test]
+    fn test_task_generator_invalid_expression() {
+        let result = TaskGenerator::new("not a cron", Local, || None);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.err().unwrap(),
+            crate::errors::TaskError::InvalidCronExpression(_)
+        ));
     }
 
     #[test]
@@ -113,7 +143,8 @@ mod test {
         // Create a generator that executes every second
         let mut generator = TaskGenerator::new("* * * * * * *", Utc, || {
             Some(Task::new("* * * * * * *", None, None, Utc))
-        });
+        })
+        .unwrap();
 
         // Initial execution time should be within the next second
         let now = Utc::now();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,34 @@
 //! `tasklet` allows you to create scheduled tasks with specific execution patterns and
 //! run them asynchronously using Tokio. It supports cron-like scheduling expressions and
 //! provides a builder pattern for easy task creation.
+//!
+//! # Highlights
+//!
+//! * **Async steps** — every task step is a closure returning a future, so steps can
+//!   `.await` real asynchronous work (I/O, timers, ...) without blocking the runtime.
+//! * **Graceful shutdown** — obtain a [`scheduler::SchedulerHandle`] via
+//!   [`TaskScheduler::handle`] before running and call `shutdown()` to stop the scheduler
+//!   cleanly, or drive shutdown with any future via [`TaskScheduler::run_until`].
+//!
+//! # Example
+//!
+//! ```no_run
+//! use tasklet::task::TaskStepStatusOk::Success;
+//! use tasklet::{TaskBuilder, TaskScheduler};
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let mut scheduler = TaskScheduler::default(chrono::Local);
+//!     let _ = scheduler.add_task(
+//!         TaskBuilder::new(chrono::Local)
+//!             .every("1 * * * * * *")
+//!             .description("A simple task")
+//!             .add_step("Step 1", || async { Ok(Success) })
+//!             .build(),
+//!     );
+//!     scheduler.run().await;
+//! }
+//! ```
 
 mod builders;
 pub mod errors;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -6,9 +6,10 @@ use chrono::prelude::*;
 use chrono::Utc;
 use futures::future::join_all;
 use futures::StreamExt;
+use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, Notify};
 use tokio::task::JoinHandle;
 
 /// Task execution possible statuses.
@@ -33,6 +34,48 @@ pub struct TaskHandle {
     is_init: bool,
 }
 
+/// A cloneable handle used to control a running [`TaskScheduler`].
+///
+/// Obtain one with [`TaskScheduler::handle`] *before* calling
+/// [`TaskScheduler::run`], then call [`SchedulerHandle::shutdown`] from anywhere
+/// (another task, a signal handler, etc.) to request a graceful stop.
+///
+/// # Examples
+///
+/// ```
+/// # use tasklet::TaskScheduler;
+/// # tokio_test::block_on(async {
+/// let mut scheduler = TaskScheduler::default(chrono::Utc);
+/// let handle = scheduler.handle();
+///
+/// // Stop the scheduler shortly after it starts.
+/// let stopper = tokio::spawn(async move {
+///     handle.shutdown();
+/// });
+///
+/// scheduler.run().await; // returns once the shutdown is requested
+/// stopper.await.unwrap();
+/// # });
+/// ```
+#[derive(Clone, Debug)]
+pub struct SchedulerHandle {
+    notify: Arc<Notify>,
+}
+
+impl SchedulerHandle {
+    /// Request a graceful shutdown of the associated scheduler.
+    ///
+    /// The scheduler finishes the current execution round, drains its tasks and
+    /// returns from [`TaskScheduler::run`]. Calling this before the scheduler
+    /// starts is fine — the request is remembered and the loop exits on its first
+    /// idle window.
+    pub fn shutdown(&self) {
+        // `notify_one` stores a permit if there is no current waiter, so a shutdown
+        // requested before `run()` reaches its await point is not lost.
+        self.notify.notify_one();
+    }
+}
+
 /// Task scheduler and executor.
 pub struct TaskScheduler<T>
 where
@@ -48,12 +91,15 @@ where
     next_id: usize,
     /// The main timezone used for the scheduler.
     timezone: T,
+    /// Notified when a graceful shutdown is requested.
+    shutdown: Arc<Notify>,
 }
 
 /// `TaskScheduler` implementation.
 impl<T> TaskScheduler<T>
 where
     T: TimeZone + Clone + Send + 'static,
+    <T as TimeZone>::Offset: Send,
 {
     /// Create a new instance of `TaskSchedule` with default sleep and no tasks to execute.
     ///
@@ -75,6 +121,22 @@ where
             sleep: 1000,
             timezone,
             next_id: 0,
+            shutdown: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Return a cloneable [`SchedulerHandle`] that can request a graceful shutdown.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tasklet::TaskScheduler;
+    /// let scheduler = TaskScheduler::default(chrono::Utc);
+    /// let _handle = scheduler.handle();
+    /// ```
+    pub fn handle(&self) -> SchedulerHandle {
+        SchedulerHandle {
+            notify: self.shutdown.clone(),
         }
     }
 
@@ -111,7 +173,7 @@ where
     /// # use tasklet::{TaskScheduler, TaskGenerator};
     /// // Create a new `TaskScheduler` instance and attach an `TaskGenerator` to it.
     /// let mut scheduler = TaskScheduler::default(chrono::Local);
-    /// let mut generator = TaskGenerator::new("1 * * * * * *", chrono::Local, || None);
+    /// let generator = TaskGenerator::new("1 * * * * * *", chrono::Local, || None).unwrap();
     /// scheduler.set_task_gen(generator);
     /// ```
     pub fn set_task_gen(&mut self, task_gen: TaskGenerator<T>) -> &mut TaskScheduler<T> {
@@ -181,7 +243,19 @@ where
         let total_runs: Arc<Mutex<usize>> = Arc::new(Mutex::new(0usize));
         futures::stream::iter(receivers)
             .for_each(|r| async {
-                match r.await.unwrap().status {
+                // A task whose sender was dropped (e.g. it panicked) yields a
+                // `RecvError`; log and skip it rather than bringing down the scheduler.
+                let status = match r.await {
+                    Ok(response) => response.status,
+                    Err(_) => {
+                        scheduler_log!(
+                            log::Level::Error,
+                            "A task failed to report its run status and will be skipped"
+                        );
+                        return;
+                    }
+                };
+                match status {
                     Status::Executed => {
                         *total_runs.lock().unwrap() += 1;
                     }
@@ -206,7 +280,16 @@ where
         }
 
         for recv in receivers {
-            let res = recv.await.unwrap();
+            let res = match recv.await {
+                Ok(res) => res,
+                Err(_) => {
+                    scheduler_log!(
+                        log::Level::Error,
+                        "A task failed to report its reschedule status and will be skipped"
+                    );
+                    continue;
+                }
+            };
             if res.status == Status::Finished || res.status == Status::ForceRemoved {
                 for handle in &self.handles {
                     if handle.id == res.id {
@@ -304,47 +387,120 @@ where
         }
     }
 
+    /// Abort every registered task and clear the handle list.
+    ///
+    /// Used on shutdown to drain the scheduler cleanly. Each task is just parked on
+    /// its receiver, so aborting is safe.
+    fn shutdown_tasks(&mut self) {
+        for handle in &self.handles {
+            handle.handle.abort();
+        }
+        self.handles.clear();
+    }
+
+    /// Run one iteration of the scheduler flow: run the generator (if due),
+    /// (re)initialize tasks and execute the current round.
+    async fn tick(&mut self) {
+        if self.run_task_gen() {
+            // Re-initialize the tasks if any new is added
+            self.init_tasks().await;
+        }
+        match self.execute_tasks().await {
+            ExecutionStatus::Success(c) => {
+                scheduler_log!(
+                    log::Level::Info,
+                    "Execution round completed successfully for {} task(s)",
+                    c
+                );
+            }
+            ExecutionStatus::HadError(c, e) => {
+                scheduler_log!(
+                    log::Level::Error,
+                    "Execution round ran {} task(s) with {} error(s)",
+                    c,
+                    e
+                );
+            }
+            _ => { /* No executions */ }
+        }
+    }
+
     /// Main execution loop.
     ///
-    /// Executes the main flow of the scheduler.
-    /// At first initialize all the tasks and then run the execution loop.
+    /// Executes the main flow of the scheduler until a shutdown is requested through a
+    /// [`SchedulerHandle`] obtained via [`TaskScheduler::handle`]. If no handle is ever
+    /// used to request a shutdown, this runs forever.
     ///
-    /// If there is a task generation/discovery method provided, executed on every loop.
+    /// At first all the tasks are initialized and then the execution loop is entered.
+    /// If a task generation/discovery method is provided, it is executed on every loop.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tasklet::TaskScheduler;
+    /// # tokio_test::block_on(async {
+    /// let mut scheduler = TaskScheduler::default(chrono::Utc);
+    /// let handle = scheduler.handle();
+    /// tokio::spawn(async move { handle.shutdown(); });
+    /// scheduler.run().await;
+    /// # });
+    /// ```
     pub async fn run(&mut self) {
+        let shutdown = self.shutdown.clone();
+        self.run_until(async move { shutdown.notified().await })
+            .await;
+    }
+
+    /// Run the scheduler until the provided `shutdown` future resolves.
+    ///
+    /// This is the general form of [`TaskScheduler::run`]; it lets callers drive the
+    /// shutdown with any future, for example an OS signal such as `ctrl_c`. When the
+    /// future resolves the current round finishes, the tasks are drained and this
+    /// returns.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tasklet::TaskScheduler;
+    /// # use std::time::Duration;
+    /// # tokio_test::block_on(async {
+    /// let mut scheduler = TaskScheduler::new(50, chrono::Utc);
+    /// // Stop after a short while.
+    /// scheduler
+    ///     .run_until(tokio::time::sleep(Duration::from_millis(120)))
+    ///     .await;
+    /// # });
+    /// ```
+    pub async fn run_until<F>(&mut self, shutdown: F)
+    where
+        F: Future<Output = ()>,
+    {
         scheduler_log!(
             log::Level::Info,
             "Scheduler started. Total tasks in queue: {}",
             self.handles.len()
         );
 
+        tokio::pin!(shutdown);
+
         // Initialize the tasks
         self.init_tasks().await;
 
         loop {
-            if self.run_task_gen() {
-                // Re-initialize the tasks if any new is added
-                self.init_tasks().await;
-            }
-            match self.execute_tasks().await {
-                ExecutionStatus::Success(c) => {
-                    scheduler_log!(
-                        log::Level::Info,
-                        "Execution round completed successfully for {} task(s)",
-                        c
-                    );
+            self.tick().await;
+            // Sleep between rounds, but wake up early if a shutdown is requested.
+            tokio::select! {
+                biased;
+                _ = &mut shutdown => {
+                    scheduler_log!(log::Level::Info, "Shutdown requested, stopping scheduler");
+                    break;
                 }
-                ExecutionStatus::HadError(c, e) => {
-                    scheduler_log!(
-                        log::Level::Error,
-                        "Execution round ran {} task(s) with {} error(s)",
-                        c,
-                        e
-                    );
-                }
-                _ => { /* No executions */ }
+                _ = tokio::time::sleep(Duration::from_millis(self.sleep as u64)) => {}
             }
-            tokio::time::sleep(Duration::from_millis(self.sleep as u64)).await;
         }
+
+        self.shutdown_tasks();
+        scheduler_log!(log::Level::Info, "Scheduler stopped");
     }
 }
 
@@ -386,7 +542,7 @@ mod test {
         let mut scheduler = TaskScheduler::new(500, Local);
         // Create a task.
         let mut task = Task::new("* * * * * * *", None, Some(1), Local).unwrap();
-        task.add_step_default(|| Err(ErrorDelete));
+        task.add_step_default(|| async { Err(ErrorDelete) });
         // Add a couple of tasks.
         scheduler
             .add_task(Ok(task))
@@ -425,9 +581,9 @@ mod test {
 
         // Create a task.
         let mut task = Task::new("* * * * * * *", None, Some(1), Local).unwrap();
-        task.add_step_default(|| Ok(Success));
+        task.add_step_default(|| async { Ok(Success) });
         // Return an error in the second step.
-        task.add_step_default(|| Err(Error));
+        task.add_step_default(|| async { Err(Error) });
 
         // Add a task.
         scheduler.add_task(Ok(task)).unwrap();
@@ -446,7 +602,7 @@ mod test {
         let mut scheduler = TaskScheduler::new(500, Local);
 
         // Add a task generator function that does now.
-        scheduler.set_task_gen(TaskGenerator::new("* * * * * * *", Local, || None));
+        scheduler.set_task_gen(TaskGenerator::new("* * * * * * *", Local, || None).unwrap());
 
         // Should start with zero tasks.
         assert_eq!(scheduler.handles.len(), 0);
@@ -459,13 +615,16 @@ mod test {
         assert_eq!(scheduler.handles.len(), 0);
 
         // Update the generator to actually create a new task.
-        scheduler.set_task_gen(TaskGenerator::new("* * * * * * *", Local, || {
-            // Run at second "1" of every minute.
+        scheduler.set_task_gen(
+            TaskGenerator::new("* * * * * * *", Local, || {
+                // Run at second "1" of every minute.
 
-            // Create the task that will execute 2 total times.
-            // Return the task for the execution queue.
-            Some(TaskBuilder::new(Local).every("* * * * * * *").build())
-        }));
+                // Create the task that will execute 2 total times.
+                // Return the task for the execution queue.
+                Some(TaskBuilder::new(Local).every("* * * * * * *").build())
+            })
+            .unwrap(),
+        );
 
         // Execute the task generator.
         tokio::time::sleep(Duration::from_millis(1000)).await;
@@ -490,5 +649,59 @@ mod test {
             Err(TaskError::InvalidCronExpression(_)) => {} // Expected
             _ => panic!("Expected InvalidCronExpression error"),
         }
+    }
+
+    /// `run()` must return once a shutdown is requested through the handle.
+    #[tokio::test]
+    async fn test_scheduler_graceful_shutdown() {
+        let mut scheduler = TaskScheduler::new(50, Local);
+        scheduler
+            .add_task(Task::new("* * * * * * *", None, None, Local))
+            .unwrap();
+
+        let handle = scheduler.handle();
+        let stopper = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            handle.shutdown();
+        });
+
+        // Should return in bounded time rather than looping forever.
+        tokio::time::timeout(Duration::from_secs(5), scheduler.run())
+            .await
+            .expect("scheduler did not stop after shutdown was requested");
+        stopper.await.unwrap();
+
+        // Tasks are drained on shutdown.
+        assert_eq!(scheduler.handles.len(), 0);
+    }
+
+    /// A shutdown requested before `run()` starts must still stop the scheduler.
+    #[tokio::test]
+    async fn test_scheduler_shutdown_requested_before_run() {
+        let mut scheduler = TaskScheduler::new(50, Local);
+        let handle = scheduler.handle();
+        // Request shutdown up-front; the stored notification must not be lost.
+        handle.shutdown();
+
+        tokio::time::timeout(Duration::from_secs(5), scheduler.run())
+            .await
+            .expect("scheduler ignored a shutdown requested before run()");
+    }
+
+    /// `run_until` stops when the provided future resolves.
+    #[tokio::test]
+    async fn test_scheduler_run_until() {
+        let mut scheduler = TaskScheduler::new(50, Local);
+        scheduler
+            .add_task(Task::new("* * * * * * *", None, None, Local))
+            .unwrap();
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            scheduler.run_until(tokio::time::sleep(Duration::from_millis(120))),
+        )
+        .await
+        .expect("run_until did not stop when its shutdown future resolved");
+        assert_eq!(scheduler.handles.len(), 0);
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -7,6 +7,8 @@ use chrono::TimeZone;
 use chrono::{DateTime, Utc};
 use cron::Schedule;
 use std::fmt::{self, Debug};
+use std::future::Future;
+use std::pin::Pin;
 use tokio::sync::{mpsc, oneshot};
 
 /// Possible success status values for a step's execution.
@@ -27,8 +29,17 @@ pub enum TaskStepStatusErr {
     ErrorDelete,
 }
 
-/// An executable function.
-pub type ExecutableFn = dyn FnMut() -> Result<TaskStepStatusOk, TaskStepStatusErr> + 'static + Send;
+/// The boxed future produced by a task step when it is invoked.
+///
+/// Steps are asynchronous: invoking a step returns a `Future` that is awaited by the
+/// scheduler, allowing steps to perform real async work (I/O, timers, etc.).
+pub type StepFuture =
+    Pin<Box<dyn Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>> + Send>>;
+
+/// An executable, asynchronous function.
+///
+/// Each call produces a fresh [`StepFuture`] to be awaited.
+pub type ExecutableFn = dyn FnMut() -> StepFuture + 'static + Send;
 
 /// A task step.
 ///
@@ -61,15 +72,16 @@ impl TaskStep {
     ///
     /// ```
     /// # use tasklet::task::{TaskStep, TaskStepStatusOk};
-    /// let _ = TaskStep::new("Some task", || Ok(TaskStepStatusOk::Success));
+    /// let _ = TaskStep::new("Some task", || async { Ok(TaskStepStatusOk::Success) });
     /// ```
-    pub fn new<F>(description: &str, function: F) -> Self
+    pub fn new<F, Fut>(description: &str, mut function: F) -> Self
     where
-        F: (FnMut() -> Result<TaskStepStatusOk, TaskStepStatusErr>) + 'static + Send,
+        F: (FnMut() -> Fut) + 'static + Send,
+        Fut: Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>> + Send + 'static,
     {
         Self {
             description: Some(description.to_string()),
-            function: Box::new(function),
+            function: Box::new(move || Box::pin(function())),
         }
     }
 
@@ -84,14 +96,15 @@ impl TaskStep {
     /// ```
     /// # use tasklet::task::TaskStep;
     /// use tasklet::task::TaskStepStatusOk::Success;
-    /// let _ = TaskStep::default(|| {Ok(Success)});
+    /// let _ = TaskStep::default(|| async { Ok(Success) });
     /// ```
-    pub fn default<F>(function: F) -> Self
+    pub fn default<F, Fut>(mut function: F) -> Self
     where
-        F: (FnMut() -> Result<TaskStepStatusOk, TaskStepStatusErr>) + 'static + Send,
+        F: (FnMut() -> Fut) + 'static + Send,
+        Fut: Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>> + Send + 'static,
     {
         Self {
-            function: Box::new(function),
+            function: Box::new(move || Box::pin(function())),
             description: None,
         }
     }
@@ -165,8 +178,6 @@ where
     /// Task receiver
     pub(crate) receiver: Option<mpsc::Receiver<TaskCmd>>,
 }
-
-unsafe impl<T> Send for Task<T> where T: TimeZone + Send + 'static {}
 
 impl<T> Debug for Task<T>
 where
@@ -266,9 +277,10 @@ where
     /// * description   - A short task step description (Optional).
     /// * function      - The executable function.
     #[cfg(test)]
-    pub(crate) fn add_step<F>(&mut self, description: &str, function: F) -> &mut Task<T>
+    pub(crate) fn add_step<F, Fut>(&mut self, description: &str, function: F) -> &mut Task<T>
     where
-        F: (FnMut() -> Result<TaskStepStatusOk, TaskStepStatusErr>) + 'static + Send,
+        F: (FnMut() -> Fut) + 'static + Send,
+        Fut: Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>> + Send + 'static,
     {
         self.steps.push(TaskStep::new(description, function));
         self
@@ -280,9 +292,10 @@ where
     ///
     /// * function  - the executable function
     #[cfg(test)]
-    pub(crate) fn add_step_default<F>(&mut self, function: F) -> &mut Task<T>
+    pub(crate) fn add_step_default<F, Fut>(&mut self, function: F) -> &mut Task<T>
     where
-        F: (FnMut() -> Result<TaskStepStatusOk, TaskStepStatusErr>) + 'static + Send,
+        F: (FnMut() -> Fut) + 'static + Send,
+        Fut: Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>> + Send + 'static,
     {
         self.steps.push(TaskStep::default(function));
         self
@@ -315,14 +328,24 @@ where
     /// * id - The task's id.
     pub(crate) fn init(&mut self) {
         task_log!(self.task_id, log::Level::Debug, "Initializing");
-        self.next_exec = Some(
-            self.schedule
-                .upcoming(self.timezone.clone())
-                .next()
-                .unwrap(),
-        );
-        self.status = Status::Scheduled;
-        task_log!(self.task_id, log::Level::Debug, "Finished initializing");
+        match self.schedule.upcoming(self.timezone.clone()).next() {
+            Some(next) => {
+                self.next_exec = Some(next);
+                self.status = Status::Scheduled;
+                task_log!(self.task_id, log::Level::Debug, "Finished initializing");
+            }
+            None => {
+                // The schedule has no upcoming execution (e.g. a cron with a fixed
+                // past year). Mark it finished so the scheduler reaps it instead of
+                // panicking on an unwrap.
+                self.status = Status::Finished;
+                task_log!(
+                    self.task_id,
+                    log::Level::Warn,
+                    "Has no upcoming execution and will be removed"
+                );
+            }
+        }
     }
 
     /// Create a `TaskResponse` from the current state of the task.
@@ -338,13 +361,23 @@ where
     /// Each of the commands triggers the underlying method of the task,
     /// and responds with the id of the task and the status of the task after the execution
     /// of the command has finished.
-    pub(crate) fn execute_command(&mut self, msg: TaskCmd) {
+    pub(crate) async fn execute_command(&mut self, msg: TaskCmd) {
         match msg {
             TaskCmd::Run { sender } => {
-                if self.next_exec.as_ref().unwrap()
-                    <= &Utc::now().with_timezone(&self.timezone.clone())
-                {
-                    let _ = self.run_task(); // Ignore the result as we already update the status
+                // Only run if the task has been scheduled (has a next execution time)
+                // and that time is due. A missing `next_exec` means the task was never
+                // initialized; skip it gracefully instead of panicking.
+                //
+                // The comparison is scoped so the borrow of `next_exec` is released
+                // before the `.await`, keeping the resulting future `Send`.
+                let due = match &self.next_exec {
+                    Some(next_exec) => {
+                        *next_exec <= Utc::now().with_timezone(&self.timezone.clone())
+                    }
+                    None => false,
+                };
+                if due {
+                    let _ = self.run_task().await; // Ignore the result as we already update the status
                 }
                 let _ = sender.send(self.get_task_response());
             }
@@ -362,7 +395,7 @@ where
     }
 
     /// Run the task and handle the output.
-    pub(crate) fn run_task(&mut self) -> TaskResult<()> {
+    pub(crate) async fn run_task(&mut self) -> TaskResult<()> {
         match &self.status {
             Status::Init => Err(TaskError::NotInitialized),
             Status::Failed => Err(TaskError::Failed),
@@ -379,7 +412,7 @@ where
                 let mut had_error: bool = false;
                 for (index, step) in self.steps.iter_mut().enumerate() {
                     if !had_error {
-                        match (step.function)() {
+                        match (step.function)().await {
                             Ok(status) => {
                                 match status {
                                     TaskStepStatusOk::Success => step_log!(
@@ -433,8 +466,9 @@ where
                     self.status = Status::Executed
                 }
 
-                // Reduce the total executions (if set).
-                self.repeats = self.repeats.map(|r| r - 1);
+                // Reduce the total executions (if set). Saturate at zero so a task
+                // constructed with `repeat(0)` cannot underflow.
+                self.repeats = self.repeats.map(|r| r.saturating_sub(1));
 
                 Ok(())
             }
@@ -446,12 +480,8 @@ where
         match &self.status {
             Status::Init => Err(TaskError::NotInitialized),
             Status::Failed | Status::Executed => {
-                self.next_exec = Some(
-                    self.schedule
-                        .upcoming(self.timezone.clone())
-                        .next()
-                        .unwrap(),
-                );
+                // Determine the next status based on the remaining repeats first: if the
+                // task is done there is no need to compute a next execution time.
                 self.status = match self.repeats {
                     Some(t) => {
                         if t > 0 {
@@ -468,6 +498,20 @@ where
                     }
                     None => Status::Scheduled,
                 };
+                if self.status == Status::Scheduled {
+                    match self.schedule.upcoming(self.timezone.clone()).next() {
+                        Some(next) => self.next_exec = Some(next),
+                        None => {
+                            // No further executions available; retire the task.
+                            task_log!(
+                                self.task_id,
+                                log::Level::Warn,
+                                "Has no upcoming execution and will be removed"
+                            );
+                            self.status = Status::Finished;
+                        }
+                    }
+                }
                 Ok(())
             }
             Status::Finished | Status::ForceRemoved => {
@@ -504,6 +548,7 @@ where
 pub async fn run_task<T>(mut task: Task<T>)
 where
     T: TimeZone + Send + 'static,
+    <T as TimeZone>::Offset: Send,
 {
     while let Some(msg) = task
         .receiver
@@ -512,7 +557,7 @@ where
         .recv()
         .await
     {
-        task.execute_command(msg);
+        task.execute_command(msg).await;
     }
 }
 
@@ -523,19 +568,19 @@ mod test {
     use crate::task::TaskStepStatusOk::Success;
     use chrono::prelude::*;
 
-    #[test]
-    fn normal_task_flow_test() {
+    #[tokio::test]
+    async fn normal_task_flow_test() {
         let mut task = Task::new("* * * * * *", Some("Test task"), Some(2), Local).unwrap();
-        task.add_step_default(|| Ok(Success));
+        task.add_step_default(|| async { Ok(Success) });
         assert_eq!(task.status, Status::Init);
         task.set_id(0);
         task.init();
         assert_eq!(task.status, Status::Scheduled);
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
         assert_eq!(task.status, Status::Executed);
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Scheduled);
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
         assert_eq!(task.status, Status::Executed);
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Finished);
@@ -546,43 +591,43 @@ mod test {
         let schedule: Schedule = "* * * * * * *".parse().unwrap();
         let mut task = Task::new("* * * * * * *", None, None, Local).unwrap();
         task.set_schedule(schedule);
-        task.add_step_default(|| Ok(Success));
+        task.add_step_default(|| async { Ok(Success) });
         assert_eq!(task.status, Status::Init);
         task.set_id(0);
         task.init();
         assert_eq!(task.status, Status::Scheduled);
     }
 
-    #[test]
-    fn normal_task_error_flow_test() {
+    #[tokio::test]
+    async fn normal_task_error_flow_test() {
         let mut task = Task::new("* * * * * *", Some("Test task"), Some(2), Local).unwrap();
-        task.add_step_default(|| Err(Error));
+        task.add_step_default(|| async { Err(Error) });
         assert_eq!(task.status, Status::Init);
         task.set_id(0);
         task.init();
         assert_eq!(task.status, Status::Scheduled);
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
         assert_eq!(task.status, Status::Failed);
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Scheduled);
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
         assert_eq!(task.status, Status::Failed);
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Finished);
     }
 
     /// Test the normal execution of a simple task, without fixed repeats.
-    #[test]
-    fn normal_task_no_fixed_repeats_test() {
+    #[tokio::test]
+    async fn normal_task_no_fixed_repeats_test() {
         let mut task = Task::new("* * * * * * *", Some("Test task"), None, Local).unwrap();
-        task.add_step_default(|| Ok(Success));
+        task.add_step_default(|| async { Ok(Success) });
         assert_eq!(task.status, Status::Init);
         task.set_id(0);
         task.init();
         assert_eq!(task.status, Status::Scheduled);
         // Run it for a few times.
         for _i in 1..10 {
-            assert!(task.run_task().is_ok());
+            assert!(task.run_task().await.is_ok());
             assert_eq!(task.status, Status::Executed);
             assert!(task.reschedule().is_ok());
             assert_eq!(task.status, Status::Scheduled);
@@ -600,76 +645,82 @@ mod test {
         ));
     }
 
-    #[test]
-    fn test_reschedule_finished_should_mark_as_finished() {
+    #[tokio::test]
+    async fn test_reschedule_finished_should_mark_as_finished() {
         let mut task = Task::new("* * * * * * *", None, Some(1), Local).unwrap();
         // Execute the task.
         task.set_id(0);
         task.init();
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Finished);
     }
 
-    #[test]
-    fn test_run_uninitialized_task() {
+    #[tokio::test]
+    async fn test_run_uninitialized_task() {
         let mut task = Task::new("* * * * * * *", None, None, Local).unwrap();
-        assert!(task.run_task().is_err());
+        assert!(task.run_task().await.is_err());
         assert!(matches!(
-            task.run_task().unwrap_err(),
+            task.run_task().await.unwrap_err(),
             TaskError::NotInitialized
         ));
     }
 
-    #[test]
-    fn test_run_failed_task() {
+    #[tokio::test]
+    async fn test_run_failed_task() {
         let mut task = Task::new("* * * * * * *", None, None, Local).unwrap();
-        task.add_step_default(|| Err(Error));
+        task.add_step_default(|| async { Err(Error) });
         task.set_id(0);
         task.init();
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
         assert_eq!(task.status, Status::Failed);
         // Attempt to rerun it, it should fail.
-        assert!(task.run_task().is_err());
-        assert!(matches!(task.run_task().unwrap_err(), TaskError::Failed));
+        assert!(task.run_task().await.is_err());
+        assert!(matches!(
+            task.run_task().await.unwrap_err(),
+            TaskError::Failed
+        ));
     }
 
-    #[test]
-    fn test_run_executed_task() {
+    #[tokio::test]
+    async fn test_run_executed_task() {
         let mut task = Task::new("* * * * * * *", None, None, Local).unwrap();
-        task.add_step("Step 1", || Ok(Success));
+        task.add_step("Step 1", || async { Ok(Success) });
         task.set_id(0);
         task.init();
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
         assert_eq!(task.status, Status::Executed);
         // Attempt to run it again, it should fail.
-        assert!(task.run_task().is_err());
+        assert!(task.run_task().await.is_err());
         assert!(matches!(
-            task.run_task().unwrap_err(),
+            task.run_task().await.unwrap_err(),
             TaskError::AlreadyExecuted
         ));
     }
 
-    #[test]
-    fn test_run_finished_task() {
+    #[tokio::test]
+    async fn test_run_finished_task() {
         let mut task = Task::new("* * * * * * *", None, Some(1), Local).unwrap();
         task.set_id(0);
         task.init();
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Finished);
         // At this point the task is Finished. It should not be allowed to run again.
-        assert!(task.run_task().is_err());
-        assert!(matches!(task.run_task().unwrap_err(), TaskError::Finished));
+        assert!(task.run_task().await.is_err());
+        assert!(matches!(
+            task.run_task().await.unwrap_err(),
+            TaskError::Finished
+        ));
     }
 
-    #[test]
-    fn test_run_failed_delete() {
+    #[tokio::test]
+    async fn test_run_failed_delete() {
         let mut task = Task::new("* * * * * * *", None, None, Local).unwrap();
-        task.add_step_default(|| Err(ErrorDelete));
+        task.add_step_default(|| async { Err(ErrorDelete) });
         task.set_id(0);
         task.init();
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
         assert_eq!(task.status, Status::ForceRemoved);
     }
 
@@ -683,8 +734,8 @@ mod test {
         ));
     }
 
-    #[test]
-    fn test_task_status_transitions() {
+    #[tokio::test]
+    async fn test_task_status_transitions() {
         let mut task = Task::new(
             "* * * * * * *",
             Some("Status transition test"),
@@ -701,10 +752,10 @@ mod test {
         assert_eq!(task.status, Status::Scheduled);
 
         // Add a step that succeeds
-        task.add_step_default(|| Ok(TaskStepStatusOk::Success));
+        task.add_step_default(|| async { Ok(TaskStepStatusOk::Success) });
 
         // After run_task(), status should be Executed
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
         assert_eq!(task.status, Status::Executed);
 
         // After reschedule(), with repeats=1 and already executed once,
@@ -716,15 +767,15 @@ mod test {
     #[test]
     fn test_task_step_display() {
         // Test with description
-        let step_with_desc = TaskStep::new("Test step", || Ok(TaskStepStatusOk::Success));
+        let step_with_desc = TaskStep::new("Test step", || async { Ok(TaskStepStatusOk::Success) });
         assert_eq!(format!("{}", step_with_desc), "Test step");
 
         // Test without description
-        let step_no_desc = TaskStep::default(|| Ok(TaskStepStatusOk::Success));
+        let step_no_desc = TaskStep::default(|| async { Ok(TaskStepStatusOk::Success) });
         assert_eq!(format!("{}", step_no_desc), "-");
 
         // Test with empty description
-        let step_empty_desc = TaskStep::new("", || Ok(TaskStepStatusOk::Success));
+        let step_empty_desc = TaskStep::new("", || async { Ok(TaskStepStatusOk::Success) });
         assert_eq!(format!("{}", step_empty_desc), "-");
     }
 
@@ -737,11 +788,12 @@ mod test {
         task.set_id(1);
 
         // Add a simple step to ensure the Run command works properly
-        task.add_step("Test step", || Ok(TaskStepStatusOk::Success));
+        task.add_step("Test step", || async { Ok(TaskStepStatusOk::Success) });
 
         // Test Init command first - this should initialize the task
         let (tx_init, rx_init) = oneshot::channel();
-        task.execute_command(TaskCmd::Init { sender: tx_init });
+        task.execute_command(TaskCmd::Init { sender: tx_init })
+            .await;
         let init_response = rx_init.await.unwrap();
         assert_eq!(init_response.id, 1);
         assert_eq!(init_response.status, Status::Scheduled);
@@ -754,7 +806,8 @@ mod test {
         let (tx_run_no_exec, rx_run_no_exec) = oneshot::channel();
         task.execute_command(TaskCmd::Run {
             sender: tx_run_no_exec,
-        });
+        })
+        .await;
         let no_exec_response = rx_run_no_exec.await.unwrap();
         assert_eq!(no_exec_response.id, 1);
         assert_eq!(
@@ -769,7 +822,7 @@ mod test {
 
         // Send Run command - this should execute the task
         let (tx_run, rx_run) = oneshot::channel();
-        task.execute_command(TaskCmd::Run { sender: tx_run });
+        task.execute_command(TaskCmd::Run { sender: tx_run }).await;
         let run_response = rx_run.await.unwrap();
         assert_eq!(run_response.id, 1);
         assert_eq!(run_response.status, Status::Executed);
@@ -778,14 +831,15 @@ mod test {
         let (tx_reschedule, rx_reschedule) = oneshot::channel();
         task.execute_command(TaskCmd::Reschedule {
             sender: tx_reschedule,
-        });
+        })
+        .await;
         let reschedule_response = rx_reschedule.await.unwrap();
         assert_eq!(reschedule_response.id, 1);
         assert_eq!(reschedule_response.status, Status::Finished);
     }
 
-    #[test]
-    fn test_task_multiple_steps_execution() {
+    #[tokio::test]
+    async fn test_task_multiple_steps_execution() {
         use std::sync::{Arc, Mutex};
 
         // Create counters to track step execution
@@ -799,25 +853,34 @@ mod test {
         // Add steps that increment counters
         let c1 = counter1.clone();
         task.add_step("Step 1", move || {
-            *c1.lock().unwrap() += 1;
-            Ok(TaskStepStatusOk::Success)
+            let c1 = c1.clone();
+            async move {
+                *c1.lock().unwrap() += 1;
+                Ok(TaskStepStatusOk::Success)
+            }
         });
 
         let c2 = counter2.clone();
         task.add_step("Step 2", move || {
-            *c2.lock().unwrap() += 1;
-            Ok(TaskStepStatusOk::Success)
+            let c2 = c2.clone();
+            async move {
+                *c2.lock().unwrap() += 1;
+                Ok(TaskStepStatusOk::Success)
+            }
         });
 
         let c3 = counter3.clone();
         task.add_step("Step 3", move || {
-            *c3.lock().unwrap() += 1;
-            Ok(TaskStepStatusOk::Success)
+            let c3 = c3.clone();
+            async move {
+                *c3.lock().unwrap() += 1;
+                Ok(TaskStepStatusOk::Success)
+            }
         });
 
         // Initialize and run
         task.init();
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
 
         // Verify all steps executed
         assert_eq!(*counter1.lock().unwrap(), 1);
@@ -828,8 +891,8 @@ mod test {
         assert_eq!(task.status, Status::Executed);
     }
 
-    #[test]
-    fn test_task_step_failure_scenarios() {
+    #[tokio::test]
+    async fn test_task_step_failure_scenarios() {
         use std::sync::{Arc, Mutex};
 
         // Create a counter to verify which steps executed
@@ -841,27 +904,36 @@ mod test {
         // First step succeeds
         let counter = execution_counter.clone();
         task.add_step("Step 1", move || {
-            counter.lock().unwrap().push(1);
-            Ok(TaskStepStatusOk::Success)
+            let counter = counter.clone();
+            async move {
+                counter.lock().unwrap().push(1);
+                Ok(TaskStepStatusOk::Success)
+            }
         });
 
         // Second step fails
         let counter = execution_counter.clone();
         task.add_step("Step 2", move || {
-            counter.lock().unwrap().push(2);
-            Err(TaskStepStatusErr::Error)
+            let counter = counter.clone();
+            async move {
+                counter.lock().unwrap().push(2);
+                Err(TaskStepStatusErr::Error)
+            }
         });
 
         // Third step should not execute due to previous failure
         let counter = execution_counter.clone();
         task.add_step("Step 3", move || {
-            counter.lock().unwrap().push(3);
-            Ok(TaskStepStatusOk::Success)
+            let counter = counter.clone();
+            async move {
+                counter.lock().unwrap().push(3);
+                Ok(TaskStepStatusOk::Success)
+            }
         });
 
         // Initialize and run
         task.init();
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
 
         // Verify only steps 1 and 2 executed
         assert_eq!(*execution_counter.lock().unwrap(), vec![1, 2]);
@@ -870,15 +942,17 @@ mod test {
         assert_eq!(task.status, Status::Failed);
     }
 
-    #[test]
-    fn test_force_removal() {
+    #[tokio::test]
+    async fn test_force_removal() {
         // Create a task with a step that forces removal
         let mut task = Task::new("* * * * * * *", Some("Force removal"), None, Local).unwrap();
-        task.add_step("Failing step", || Err(TaskStepStatusErr::ErrorDelete));
+        task.add_step("Failing step", || async {
+            Err(TaskStepStatusErr::ErrorDelete)
+        });
 
         // Initialize and run
         task.init();
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
 
         // Verify task is marked for force removal
         assert_eq!(task.status, Status::ForceRemoved);
@@ -888,16 +962,56 @@ mod test {
         assert_eq!(task.status, Status::ForceRemoved);
     }
 
-    #[test]
-    fn test_empty_task_execution() {
+    #[tokio::test]
+    async fn test_empty_task_execution() {
         // Create a task with no steps
         let mut task = Task::new("* * * * * * *", Some("Empty task"), None, Local).unwrap();
 
         // Initialize and run
         task.init();
-        assert!(task.run_task().is_ok());
+        assert!(task.run_task().await.is_ok());
 
         // Verify task is marked as Executed even with no steps
         assert_eq!(task.status, Status::Executed);
+    }
+
+    /// A step that actually awaits should be driven to completion by `run_task`.
+    #[tokio::test]
+    async fn test_async_step_is_awaited() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let ran = Arc::new(AtomicBool::new(false));
+        let flag = ran.clone();
+
+        let mut task = Task::new("* * * * * * *", Some("Async step"), Some(1), Utc).unwrap();
+        task.add_step("Awaits", move || {
+            let flag = flag.clone();
+            async move {
+                // Yield to the runtime to prove the future is actually polled/awaited.
+                tokio::task::yield_now().await;
+                flag.store(true, Ordering::SeqCst);
+                Ok(TaskStepStatusOk::Success)
+            }
+        });
+
+        task.init();
+        assert!(task.run_task().await.is_ok());
+        assert!(ran.load(Ordering::SeqCst), "async step body must run");
+        assert_eq!(task.status, Status::Executed);
+    }
+
+    /// A task built with `repeat(0)` must not underflow when executed (B6 regression).
+    #[tokio::test]
+    async fn test_repeat_zero_does_not_underflow() {
+        let mut task = Task::new("* * * * * * *", Some("Zero repeats"), Some(0), Utc).unwrap();
+        task.add_step_default(|| async { Ok(Success) });
+        task.init();
+        // Would panic with an integer underflow before the `saturating_sub` fix.
+        assert!(task.run_task().await.is_ok());
+        assert_eq!(task.repeats, Some(0));
+        // With no repeats left, the task is retired on reschedule.
+        assert!(task.reschedule().is_ok());
+        assert_eq!(task.status, Status::Finished);
     }
 }


### PR DESCRIPTION
- Made task steps asynchronous: steps now return a future and can .await real work (breaking change)
- Added graceful shutdown via SchedulerHandle::shutdown() and TaskScheduler::run_until()
- Removed the unsound `unsafe impl Send for Task`
- Replaced hot-path unwraps with graceful log-and-skip on task RecvError
- TaskGenerator::new now returns a Result instead of panicking on invalid cron expressions
- Fixed repeats underflow for tasks built with repeat(0)
- Trimmed tokio to the minimal feature set required by the library
- Updated examples, README (with 0.2.x -> 0.3.0 migration notes) and crate docs
- Added unit tests covering async steps and the graceful shutdown paths