### PR TITLE
release: v0.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,11 @@ jobs:
             rustfmt --version
             cargo fmt -- --check
       - run:
+          name: Clippy
+          command: cargo clippy --all-targets -- -D warnings
+      - run:
           name: Stable Build
-          command: cargo build
+          command: cargo build --all-targets
       - run:
           name: Test
           command: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release (publish to crates.io)
+
+# Runs when a pull request is merged into main (i.e. a push lands on main).
+# It only publishes when the version in Cargo.toml is one that does not yet exist
+# on crates.io, so ordinary merges that don't bump the version are a no-op.
+on:
+  push:
+    branches: [ main ]
+
+# Never let two publish runs overlap.
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Cheap gate: work out the crate version and whether it is already published.
+  # Ordinary merges stop here without spinning up the full build.
+  check:
+    name: Check version
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read crate name and version
+        id: meta
+        run: |
+          name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].name')
+          version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Crate: $name, version: $version"
+
+      - name: Check whether the version is already on crates.io
+        id: check
+        run: |
+          name='${{ steps.meta.outputs.name }}'
+          version='${{ steps.meta.outputs.version }}'
+          # Build the crate's sparse-index path (same scheme crates.io uses).
+          lower=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
+          len=${#lower}
+          if   [ "$len" -eq 1 ]; then path="1/$lower";
+          elif [ "$len" -eq 2 ]; then path="2/$lower";
+          elif [ "$len" -eq 3 ]; then path="3/${lower:0:1}/$lower";
+          else path="${lower:0:2}/${lower:2:2}/$lower"; fi
+          url="https://index.crates.io/$path"
+          echo "Index URL: $url"
+          # `|| true` so a 404 (crate/version not found) does not fail the step.
+          body=$(curl -sSL "$url" || true)
+          if printf '%s' "$body" | grep -qF "\"vers\":\"$version\""; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "Version $version is already published, nothing to do."
+          else
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "Version $version is new, it will be published."
+          fi
+
+  # Full gate + publish. Only runs when `check` decided the version is new.
+  publish:
+    name: Build and publish
+    needs: check
+    if: needs.check.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update Rust
+        run: rustup update stable
+
+      # Quality gate: never publish something that would not pass CI.
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Build
+        run: cargo build --verbose --all-targets
+
+      - name: Test
+        run: cargo test --verbose
+
+      - name: Doc tests
+        run: cargo test --doc --verbose
+
+      - name: Dry-run package
+        run: cargo publish --dry-run
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust Build and Test
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, 'v*' ]
   pull_request:
     branches: [ main, dev ]
 
@@ -16,13 +16,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Update Rust
         run: rustup update stable
 
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --verbose --all-targets
 
       - name: Run tests
         run: cargo test --verbose
@@ -35,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Update rust
         run: rustup update stable
@@ -53,7 +59,7 @@ jobs:
           cargo tarpaulin --verbose --all-features --workspace --timeout 120 --run-types Tests --run-types Doctests --out Xml
 
       - name: Coverage upload
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           fail_ci_if_error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tasklet"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Stavros Grigoriou <unix121@protonmail.com>"]
 edition = "2021"
 rust-version = "1.90.0"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![License](https://img.shields.io/github/license/stav121/tasklet?style=for-the-badge&color=lightgrey&logo=amazoniam&logoColor=white)](https://github.com/stav121/tasklet/blob/main/LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/stav121/tasklet?style=for-the-badge&color=yellow&logo=github)](https://github.com/stav121/tasklet/issues)
 
-⏱️ An asynchronous task scheduling library written in Rust
+An asynchronous task scheduling library written in Rust
 
 ## About
 
@@ -34,7 +34,7 @@ In your `Cargo.toml` add:
 
 ```
 [dependencies]
-tasklet = "0.3.0"
+tasklet = "0.3.1"
 ```
 
 > **Upgrading from 0.2.x?** See the [migration notes](#migrating-from-02x-to-030) below —
@@ -125,6 +125,41 @@ scheduler.run().await; // returns once shutdown is requested
 
 You can also drive the shutdown with any future via `scheduler.run_until(future)` — for
 example a timer or an OS signal.
+
+## Timeouts, retries and lifecycle callbacks
+
+Tasks can be made resilient with a few optional builder settings (all non-breaking,
+added in 0.3.1):
+
+```rust,no_run
+use std::time::Duration;
+use tasklet::task::TaskStepStatusOk::Success;
+use tasklet::{RetryPolicy, TaskBuilder};
+
+let _task = TaskBuilder::new(chrono::Local)
+    .every("1 * * * * * *")
+    // Cancel any single step attempt that runs longer than this.
+    .timeout(Duration::from_secs(5))
+    // Retry failing steps with exponential backoff (100ms, 200ms, 400ms), capped at 2s.
+    .retry(RetryPolicy::exponential(3, Duration::from_millis(100), 2)
+        .with_max_delay(Duration::from_secs(2)))
+    // Async lifecycle hooks.
+    .on_success(|| async { println!("run succeeded"); })
+    .on_failure(|| async { eprintln!("run failed"); })
+    .on_finish(|| async { println!("task finished its lifecycle"); })
+    .add_step("Step", || async { Ok(Success) })
+    .build();
+```
+
+- **Timeout** (`.timeout`) bounds each individual step attempt; a step that exceeds it is
+  cancelled and treated as a (retryable) failure.
+- **Retry** (`.retry`) re-attempts a step that returns `TaskStepStatusErr::Error` (or times
+  out). Use `RetryPolicy::fixed` or `RetryPolicy::exponential`. A step returning
+  `TaskStepStatusErr::ErrorDelete` bypasses retries and removes the task immediately.
+- **Callbacks** (`.on_success` / `.on_failure` / `.on_finish`) are async hooks;
+  `on_finish` fires once when the task reaches a terminal state.
+
+See [`examples/retry_timeout_example.rs`](/examples/retry_timeout_example.rs) for a runnable demo.
 
 ## Migrating from 0.2.x to 0.3.0
 

--- a/examples/retry_timeout_example.rs
+++ b/examples/retry_timeout_example.rs
@@ -1,0 +1,70 @@
+use log::info;
+use simple_logger::SimpleLogger;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tasklet::task::TaskStepStatusErr::Error;
+use tasklet::task::TaskStepStatusOk::Success;
+use tasklet::{RetryPolicy, TaskBuilder, TaskScheduler};
+
+/// Showcase of the resilience features added in 0.3.1:
+///
+/// * `.timeout(..)`  — bounds each individual step attempt.
+/// * `.retry(..)`    — re-attempts failing steps with a backoff policy.
+/// * `.on_success` / `.on_failure` / `.on_finish` — async lifecycle callbacks.
+///
+/// The task runs a single time (`repeat(1)`). Its step fails on the first two
+/// attempts and succeeds on the third, so the retry policy is exercised, then the
+/// task finishes its lifecycle. The scheduler is driven with `run_until` so the
+/// program exits on its own after a few seconds.
+#[tokio::main]
+async fn main() {
+    SimpleLogger::new().init().unwrap();
+
+    // Counts how many times the step's body has been invoked (across retries).
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let step_attempts = attempts.clone();
+
+    let mut scheduler = TaskScheduler::new(250, chrono::Local);
+
+    let _ = scheduler.add_task(
+        TaskBuilder::new(chrono::Local)
+            .every("* * * * * * *")
+            .description("A flaky task guarded by a timeout and retries")
+            .repeat(1)
+            // Cancel any single attempt that runs longer than 2 seconds.
+            .timeout(Duration::from_secs(2))
+            // Retry up to 3 times with exponential backoff (100ms, 200ms, 400ms),
+            // capped at 1 second.
+            .retry(
+                RetryPolicy::exponential(3, Duration::from_millis(100), 2)
+                    .with_max_delay(Duration::from_secs(1)),
+            )
+            // Async lifecycle callbacks.
+            .on_success(|| async { info!("run succeeded") })
+            .on_failure(|| async { info!("run failed after exhausting retries") })
+            .on_finish(|| async { info!("task finished its lifecycle") })
+            .add_step("Flaky step", move || {
+                let attempts = step_attempts.clone();
+                async move {
+                    let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                    if attempt < 2 {
+                        info!("attempt #{} failing, will be retried", attempt + 1);
+                        Err(Error)
+                    } else {
+                        info!("attempt #{} succeeding", attempt + 1);
+                        Ok(Success)
+                    }
+                }
+            })
+            .build(),
+    );
+
+    // Run for a few seconds, then stop cleanly — long enough for the task to run,
+    // retry and finish.
+    scheduler
+        .run_until(tokio::time::sleep(Duration::from_secs(5)))
+        .await;
+
+    info!("total step attempts: {}", attempts.load(Ordering::SeqCst));
+}

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -1,7 +1,12 @@
 use crate::errors::{TaskError, TaskResult};
-use crate::task::{Task, TaskStep, TaskStepStatusErr, TaskStepStatusOk};
+use crate::retry::RetryPolicy;
+use crate::task::{
+    boxed_callback, CallbackFn, Task, TaskStep, TaskStepStatusErr, TaskStepStatusOk,
+};
 use chrono::TimeZone;
 use cron::Schedule;
+use std::future::Future;
+use std::time::Duration;
 
 /// Task builder function.
 ///
@@ -21,6 +26,16 @@ where
     expression: String,
     /// Max number of repeats.
     repeats: Option<usize>,
+    /// (Optional) per-step execution timeout.
+    timeout: Option<Duration>,
+    /// (Optional) retry policy for failing steps.
+    retry_policy: Option<RetryPolicy>,
+    /// (Optional) callback invoked after a successful execution.
+    on_success: Option<Box<CallbackFn>>,
+    /// (Optional) callback invoked after a failed execution.
+    on_failure: Option<Box<CallbackFn>>,
+    /// (Optional) callback invoked once the task reaches a terminal state.
+    on_finish: Option<Box<CallbackFn>>,
     /// The Task/Scheduler timezone.
     timezone: T,
 }
@@ -48,6 +63,11 @@ where
             schedule: None,
             expression: "* * * * * * *".to_string(), // Default expression
             repeats: None,
+            timeout: None,
+            retry_policy: None,
+            on_success: None,
+            on_failure: None,
+            on_finish: None,
             timezone,
         }
     }
@@ -107,6 +127,133 @@ where
     /// ```
     pub fn repeat(mut self, repeat: usize) -> TaskBuilder<T> {
         self.repeats = Some(repeat);
+        self
+    }
+
+    /// Set a per-step execution timeout for the generated `Task`.
+    ///
+    /// A step whose future does not resolve within `timeout` is cancelled and
+    /// treated as a (retryable) failure.
+    ///
+    /// # Arguments
+    ///
+    /// * timeout   - The maximum duration allowed for a single step attempt.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use std::time::Duration;
+    /// # use tasklet::TaskBuilder;
+    /// let _task = TaskBuilder::new(chrono::Local)
+    ///     .every("* * * * * * *")
+    ///     .timeout(Duration::from_secs(5))
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn timeout(mut self, timeout: Duration) -> TaskBuilder<T> {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    /// Set the retry policy applied to failing steps of the generated `Task`.
+    ///
+    /// Only steps returning [`TaskStepStatusErr::Error`] (or timing out) are retried;
+    /// [`TaskStepStatusErr::ErrorDelete`] bypasses retries.
+    ///
+    /// # Arguments
+    ///
+    /// * policy    - The [`RetryPolicy`] to apply.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use std::time::Duration;
+    /// # use tasklet::{RetryPolicy, TaskBuilder};
+    /// let _task = TaskBuilder::new(chrono::Local)
+    ///     .every("* * * * * * *")
+    ///     .retry(RetryPolicy::fixed(3, Duration::from_millis(100)))
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn retry(mut self, policy: RetryPolicy) -> TaskBuilder<T> {
+        self.retry_policy = Some(policy);
+        self
+    }
+
+    /// Register a callback invoked after each successful execution of the task.
+    ///
+    /// # Arguments
+    ///
+    /// * callback  - An async closure invoked when a run completes successfully.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tasklet::TaskBuilder;
+    /// let _task = TaskBuilder::new(chrono::Local)
+    ///     .every("* * * * * * *")
+    ///     .on_success(|| async { println!("task succeeded"); })
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn on_success<F, Fut>(mut self, callback: F) -> TaskBuilder<T>
+    where
+        F: (FnMut() -> Fut) + 'static + Send,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_success = Some(boxed_callback(callback));
+        self
+    }
+
+    /// Register a callback invoked after a failed execution of the task.
+    ///
+    /// # Arguments
+    ///
+    /// * callback  - An async closure invoked when a run fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tasklet::TaskBuilder;
+    /// let _task = TaskBuilder::new(chrono::Local)
+    ///     .every("* * * * * * *")
+    ///     .on_failure(|| async { eprintln!("task failed"); })
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn on_failure<F, Fut>(mut self, callback: F) -> TaskBuilder<T>
+    where
+        F: (FnMut() -> Fut) + 'static + Send,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_failure = Some(boxed_callback(callback));
+        self
+    }
+
+    /// Register a callback invoked once when the task reaches a terminal state
+    /// (its repeat cycle is exhausted or it is force-removed).
+    ///
+    /// # Arguments
+    ///
+    /// * callback  - An async closure invoked when the task finishes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tasklet::TaskBuilder;
+    /// let _task = TaskBuilder::new(chrono::Local)
+    ///     .every("* * * * * * *")
+    ///     .repeat(1)
+    ///     .on_finish(|| async { println!("task finished"); })
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn on_finish<F, Fut>(mut self, callback: F) -> TaskBuilder<T>
+    where
+        F: (FnMut() -> Fut) + 'static + Send,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_finish = Some(boxed_callback(callback));
         self
     }
 
@@ -193,6 +340,17 @@ where
 
         // Set the steps
         task.set_steps(self.steps);
+
+        // Transfer the optional timeout / retry configuration.
+        if let Some(timeout) = self.timeout {
+            task.set_timeout(timeout);
+        }
+        if let Some(policy) = self.retry_policy {
+            task.set_retry_policy(policy);
+        }
+
+        // Transfer the lifecycle callbacks.
+        task.set_callbacks(self.on_success, self.on_failure, self.on_finish);
 
         Ok(task)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,13 @@
 //!
 //! * **Async steps** — every task step is a closure returning a future, so steps can
 //!   `.await` real asynchronous work (I/O, timers, ...) without blocking the runtime.
-//! * **Graceful shutdown** — obtain a [`scheduler::SchedulerHandle`] via
+//! * **Graceful shutdown** — obtain a [`SchedulerHandle`] via
 //!   [`TaskScheduler::handle`] before running and call `shutdown()` to stop the scheduler
 //!   cleanly, or drive shutdown with any future via [`TaskScheduler::run_until`].
+//! * **Resilience** — configure a per-step [`TaskBuilder::timeout`], a
+//!   [`RetryPolicy`] via [`TaskBuilder::retry`], and async lifecycle
+//!   callbacks ([`TaskBuilder::on_success`] / [`on_failure`](TaskBuilder::on_failure) /
+//!   [`on_finish`](TaskBuilder::on_finish)).
 //!
 //! # Example
 //!
@@ -35,13 +39,15 @@
 mod builders;
 pub mod errors;
 mod generator;
+pub mod retry;
 mod scheduler;
 pub mod task;
 
 pub use builders::TaskBuilder;
 pub use errors::{TaskError, TaskResult};
 pub use generator::TaskGenerator;
-pub use scheduler::TaskScheduler;
+pub use retry::{Backoff, RetryPolicy};
+pub use scheduler::{SchedulerHandle, TaskScheduler};
 pub use task::Task;
 
 /// Macro for consistent task-related logging

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,186 @@
+//! Retry policies for task steps.
+//!
+//! A [`RetryPolicy`] controls how many times a failing step is re-attempted and how
+//! long to wait between attempts. Only steps returning
+//! [`TaskStepStatusErr::Error`](crate::task::TaskStepStatusErr::Error) (or timing out)
+//! are retried; a step returning
+//! [`TaskStepStatusErr::ErrorDelete`](crate::task::TaskStepStatusErr::ErrorDelete)
+//! bypasses retries and removes the task immediately.
+
+use std::time::Duration;
+
+/// The delay strategy applied between retry attempts.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Backoff {
+    /// Wait the same fixed duration before every retry.
+    Fixed(Duration),
+    /// Wait `base * factor^n` before retry `n` (0-indexed), optionally capped at `max`.
+    Exponential {
+        /// The delay before the first retry.
+        base: Duration,
+        /// The multiplier applied for each subsequent retry.
+        factor: u32,
+        /// An optional upper bound on the computed delay.
+        max: Option<Duration>,
+    },
+}
+
+/// A policy describing how a failing step should be retried.
+///
+/// # Examples
+///
+/// ```
+/// # use std::time::Duration;
+/// # use tasklet::RetryPolicy;
+/// // Retry up to 3 times, waiting 100ms between attempts.
+/// let _ = RetryPolicy::fixed(3, Duration::from_millis(100));
+///
+/// // Retry up to 5 times with exponential backoff (200ms, 400ms, 800ms, ...),
+/// // capped at 2 seconds.
+/// let _ = RetryPolicy::exponential(5, Duration::from_millis(200), 2)
+///     .with_max_delay(Duration::from_secs(2));
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct RetryPolicy {
+    /// The maximum number of *additional* attempts after the initial one.
+    pub max_retries: usize,
+    /// The backoff strategy applied between attempts.
+    pub backoff: Backoff,
+}
+
+impl RetryPolicy {
+    /// Create a policy that retries with a constant delay between attempts.
+    ///
+    /// # Arguments
+    ///
+    /// * max_retries - the maximum number of retries after the first attempt.
+    /// * delay       - the fixed delay to wait before each retry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// # use tasklet::RetryPolicy;
+    /// let _ = RetryPolicy::fixed(3, Duration::from_millis(250));
+    /// ```
+    pub fn fixed(max_retries: usize, delay: Duration) -> Self {
+        RetryPolicy {
+            max_retries,
+            backoff: Backoff::Fixed(delay),
+        }
+    }
+
+    /// Create a policy that retries with exponentially increasing delays.
+    ///
+    /// The delay before retry `n` (0-indexed) is `base * factor^n`.
+    ///
+    /// # Arguments
+    ///
+    /// * max_retries - the maximum number of retries after the first attempt.
+    /// * base        - the delay before the first retry.
+    /// * factor      - the multiplier applied for each subsequent retry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// # use tasklet::RetryPolicy;
+    /// let _ = RetryPolicy::exponential(4, Duration::from_millis(100), 2);
+    /// ```
+    pub fn exponential(max_retries: usize, base: Duration, factor: u32) -> Self {
+        RetryPolicy {
+            max_retries,
+            backoff: Backoff::Exponential {
+                base,
+                factor,
+                max: None,
+            },
+        }
+    }
+
+    /// Cap the computed delay at `max` (only affects [`Backoff::Exponential`]).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// # use tasklet::RetryPolicy;
+    /// let _ = RetryPolicy::exponential(4, Duration::from_millis(100), 2)
+    ///     .with_max_delay(Duration::from_secs(1));
+    /// ```
+    pub fn with_max_delay(mut self, max: Duration) -> Self {
+        if let Backoff::Exponential { max: ref mut m, .. } = self.backoff {
+            *m = Some(max);
+        }
+        self
+    }
+
+    /// Compute the delay to wait before the retry at the given (0-indexed) position.
+    ///
+    /// Overflow-safe: an exponential delay that would overflow saturates rather than
+    /// panicking.
+    pub(crate) fn delay(&self, retry_index: u32) -> Duration {
+        match &self.backoff {
+            Backoff::Fixed(d) => *d,
+            Backoff::Exponential { base, factor, max } => {
+                let mult = (*factor as u128).saturating_pow(retry_index);
+                let millis = base.as_millis().saturating_mul(mult);
+                let delay = Duration::from_millis(millis.min(u64::MAX as u128) as u64);
+                match max {
+                    Some(cap) => delay.min(*cap),
+                    None => delay,
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn fixed_delay_is_constant() {
+        let policy = RetryPolicy::fixed(3, Duration::from_millis(100));
+        assert_eq!(policy.max_retries, 3);
+        assert_eq!(policy.delay(0), Duration::from_millis(100));
+        assert_eq!(policy.delay(1), Duration::from_millis(100));
+        assert_eq!(policy.delay(5), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn exponential_delay_grows() {
+        let policy = RetryPolicy::exponential(5, Duration::from_millis(100), 2);
+        assert_eq!(policy.delay(0), Duration::from_millis(100));
+        assert_eq!(policy.delay(1), Duration::from_millis(200));
+        assert_eq!(policy.delay(2), Duration::from_millis(400));
+        assert_eq!(policy.delay(3), Duration::from_millis(800));
+    }
+
+    #[test]
+    fn exponential_delay_is_capped() {
+        let policy = RetryPolicy::exponential(10, Duration::from_millis(100), 2)
+            .with_max_delay(Duration::from_millis(500));
+        assert_eq!(policy.delay(0), Duration::from_millis(100));
+        assert_eq!(policy.delay(2), Duration::from_millis(400));
+        // 800ms would exceed the cap, so it is clamped.
+        assert_eq!(policy.delay(3), Duration::from_millis(500));
+        assert_eq!(policy.delay(10), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn exponential_delay_does_not_overflow() {
+        let policy = RetryPolicy::exponential(usize::MAX, Duration::from_secs(1), 10)
+            .with_max_delay(Duration::from_secs(30));
+        // A huge retry index would overflow a naive `base * factor^n`; saturation
+        // keeps it clamped at the configured maximum.
+        assert_eq!(policy.delay(1000), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn with_max_delay_is_noop_for_fixed() {
+        let policy = RetryPolicy::fixed(2, Duration::from_millis(50))
+            .with_max_delay(Duration::from_millis(10));
+        assert_eq!(policy.delay(0), Duration::from_millis(50));
+    }
+}

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -296,7 +296,7 @@ where
                         task_log!(
                             res.id,
                             log::Level::Debug,
-                            "Killing task due to {}",
+                            "Removing task due to {}",
                             if res.status == Status::Finished {
                                 "end of execution cycle"
                             } else {
@@ -358,7 +358,7 @@ where
                 Err(_) => {
                     scheduler_log!(
                         log::Level::Error,
-                        "RecvError returned by at least one uninitialized task"
+                        "A task failed to report its init status and will be skipped"
                     );
                 }
             });
@@ -477,7 +477,7 @@ where
     {
         scheduler_log!(
             log::Level::Info,
-            "Scheduler started. Total tasks in queue: {}",
+            "Scheduler started with {} task(s) in queue",
             self.handles.len()
         );
 
@@ -486,16 +486,28 @@ where
         // Initialize the tasks
         self.init_tasks().await;
 
+        // Drive the loop with an `Interval` rather than sleeping for a fixed amount
+        // *after* each round. `sleep` would add the duration of `tick()` to every
+        // cycle, so the poll cadence would slowly drift and long rounds could push
+        // ticks past their intended time. An interval anchors ticks to a fixed
+        // wall-clock cadence; `Skip` collapses missed ticks (when a round overruns
+        // the period) instead of firing a burst of catch-up ticks. (B7)
+        let mut interval = tokio::time::interval(Duration::from_millis(self.sleep as u64));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
         loop {
-            self.tick().await;
-            // Sleep between rounds, but wake up early if a shutdown is requested.
+            // Wake up on either a due tick or a shutdown request, whichever comes
+            // first. The first `interval.tick()` resolves immediately, so the first
+            // round runs without delay.
             tokio::select! {
                 biased;
                 _ = &mut shutdown => {
                     scheduler_log!(log::Level::Info, "Shutdown requested, stopping scheduler");
                     break;
                 }
-                _ = tokio::time::sleep(Duration::from_millis(self.sleep as u64)) => {}
+                _ = interval.tick() => {
+                    self.tick().await;
+                }
             }
         }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -2,6 +2,7 @@ extern crate chrono;
 extern crate cron;
 
 use crate::errors::{TaskError, TaskResult};
+use crate::retry::RetryPolicy;
 use crate::{step_log, task_log};
 use chrono::TimeZone;
 use chrono::{DateTime, Utc};
@@ -9,6 +10,7 @@ use cron::Schedule;
 use std::fmt::{self, Debug};
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 
 /// Possible success status values for a step's execution.
@@ -40,6 +42,23 @@ pub type StepFuture =
 ///
 /// Each call produces a fresh [`StepFuture`] to be awaited.
 pub type ExecutableFn = dyn FnMut() -> StepFuture + 'static + Send;
+
+/// The boxed future produced by a lifecycle callback when it is invoked.
+pub type CallbackFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// An asynchronous lifecycle callback (on-success / on-failure / on-finish).
+///
+/// Each call produces a fresh [`CallbackFuture`] to be awaited by the scheduler.
+pub type CallbackFn = dyn FnMut() -> CallbackFuture + 'static + Send;
+
+/// Box an async closure into a [`CallbackFn`].
+pub(crate) fn boxed_callback<F, Fut>(mut callback: F) -> Box<CallbackFn>
+where
+    F: (FnMut() -> Fut) + 'static + Send,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    Box::new(move || Box::pin(callback()))
+}
 
 /// A task step.
 ///
@@ -177,6 +196,17 @@ where
     pub(crate) status: Status,
     /// Task receiver
     pub(crate) receiver: Option<mpsc::Receiver<TaskCmd>>,
+    /// (Optional) per-step execution timeout. A step exceeding it is cancelled and
+    /// treated as a (retryable) failure.
+    pub(crate) timeout: Option<Duration>,
+    /// (Optional) retry policy applied to failing steps.
+    pub(crate) retry_policy: Option<RetryPolicy>,
+    /// (Optional) callback invoked after a successful execution.
+    pub(crate) on_success: Option<Box<CallbackFn>>,
+    /// (Optional) callback invoked after a failed execution.
+    pub(crate) on_failure: Option<Box<CallbackFn>>,
+    /// (Optional) callback invoked once when the task reaches a terminal state.
+    pub(crate) on_finish: Option<Box<CallbackFn>>,
 }
 
 impl<T> Debug for Task<T>
@@ -190,6 +220,8 @@ where
             .field("status", &self.status)
             .field("repeats", &self.repeats)
             .field("next_exec", &self.next_exec)
+            .field("timeout", &self.timeout)
+            .field("retry_policy", &self.retry_policy)
             .finish()
     }
 }
@@ -243,6 +275,11 @@ where
             status: Status::default(),
             next_exec: None,
             receiver: None,
+            timeout: None,
+            retry_policy: None,
+            on_success: None,
+            on_failure: None,
+            on_finish: None,
         })
     }
 
@@ -321,6 +358,38 @@ where
         self
     }
 
+    /// Set the per-step execution timeout.
+    pub(crate) fn set_timeout(&mut self, timeout: Duration) -> &mut Task<T> {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    /// Set the retry policy for failing steps.
+    pub(crate) fn set_retry_policy(&mut self, policy: RetryPolicy) -> &mut Task<T> {
+        self.retry_policy = Some(policy);
+        self
+    }
+
+    /// Set the callbacks invoked over the task's lifecycle.
+    pub(crate) fn set_callbacks(
+        &mut self,
+        on_success: Option<Box<CallbackFn>>,
+        on_failure: Option<Box<CallbackFn>>,
+        on_finish: Option<Box<CallbackFn>>,
+    ) -> &mut Task<T> {
+        self.on_success = on_success;
+        self.on_failure = on_failure;
+        self.on_finish = on_finish;
+        self
+    }
+
+    /// Invoke a lifecycle callback if it is set.
+    async fn fire_callback(callback: &mut Option<Box<CallbackFn>>) {
+        if let Some(callback) = callback.as_mut() {
+            callback().await;
+        }
+    }
+
     /// Initialize the `Task` instance and schedule the first execution.
     ///
     /// # Arguments
@@ -378,11 +447,29 @@ where
                 };
                 if due {
                     let _ = self.run_task().await; // Ignore the result as we already update the status
+                                                   // Fire the relevant lifecycle callbacks based on the outcome.
+                                                   // `on_finish` for a force-removed task is fired here since that
+                                                   // is its terminal state; a normally-finishing task fires it in
+                                                   // the reschedule branch below.
+                    match self.status {
+                        Status::Executed => Self::fire_callback(&mut self.on_success).await,
+                        Status::Failed => Self::fire_callback(&mut self.on_failure).await,
+                        Status::ForceRemoved => {
+                            Self::fire_callback(&mut self.on_failure).await;
+                            Self::fire_callback(&mut self.on_finish).await;
+                        }
+                        _ => {}
+                    }
                 }
                 let _ = sender.send(self.get_task_response());
             }
             TaskCmd::Reschedule { sender } => {
                 let _ = self.reschedule(); // Ignore the result as we already update the status
+                                           // A task that has just reached the `Finished` state fires `on_finish`
+                                           // exactly once (force-removed tasks already fired it in the Run branch).
+                if self.status == Status::Finished {
+                    Self::fire_callback(&mut self.on_finish).await;
+                }
                 let _ = sender.send(self.get_task_response());
             }
             TaskCmd::Init { sender } => {
@@ -409,10 +496,47 @@ where
                     "Executing '{}'",
                     self.description
                 );
+                // Snapshot the timeout / retry configuration before borrowing
+                // `self.steps` mutably below.
+                let timeout = self.timeout;
+                let retry = self.retry_policy.clone();
+                let max_attempts = 1 + retry.as_ref().map(|r| r.max_retries).unwrap_or(0);
+
                 let mut had_error: bool = false;
                 for (index, step) in self.steps.iter_mut().enumerate() {
-                    if !had_error {
-                        match (step.function)().await {
+                    if had_error {
+                        break;
+                    }
+                    // Attempt the step, retrying transient (`Error`) failures and
+                    // timeouts according to the retry policy. `ErrorDelete` and
+                    // success both terminate the attempt loop immediately.
+                    let mut attempt: u32 = 0;
+                    loop {
+                        attempt += 1;
+
+                        // Run the step, optionally bounded by the configured timeout.
+                        // A timeout is treated as a (retryable) `Error`.
+                        let result = match timeout {
+                            Some(duration) => {
+                                match tokio::time::timeout(duration, (step.function)()).await {
+                                    Ok(result) => result,
+                                    Err(_) => {
+                                        step_log!(
+                                            self.task_id,
+                                            index,
+                                            log::Level::Warn,
+                                            "Timed out after {:?} - {}",
+                                            duration,
+                                            step
+                                        );
+                                        Err(TaskStepStatusErr::Error)
+                                    }
+                                }
+                            }
+                            None => (step.function)().await,
+                        };
+
+                        match result {
                             Ok(status) => {
                                 match status {
                                     TaskStepStatusOk::Success => step_log!(
@@ -430,35 +554,53 @@ where
                                         step
                                     ),
                                 }
-                                self.status = Status::Executed
+                                self.status = Status::Executed;
+                                break;
                             }
-                            Err(status) => {
-                                // Indicate that there was an error.
+                            Err(TaskStepStatusErr::ErrorDelete) => {
+                                step_log!(
+                                    self.task_id,
+                                    index,
+                                    log::Level::Error,
+                                    "Execution failed and task is marked for deletion - {}",
+                                    step
+                                );
+                                self.status = Status::ForceRemoved;
                                 had_error = true;
-                                match status {
-                                    TaskStepStatusErr::Error => {
-                                        step_log!(
-                                            self.task_id,
-                                            index,
-                                            log::Level::Error,
-                                            "Execution failed - {}",
-                                            step
-                                        );
-                                        self.status = Status::Failed
-                                    }
-                                    TaskStepStatusErr::ErrorDelete => {
-                                        step_log!(
-                                            self.task_id,
-                                            index,
-                                            log::Level::Error,
-                                            "Execution failed and task is marked for deletion - {}",
-                                            step
-                                        );
-                                        self.status = Status::ForceRemoved
-                                    }
-                                }
+                                break;
                             }
-                        };
+                            Err(TaskStepStatusErr::Error) => {
+                                if (attempt as usize) < max_attempts {
+                                    // `retry` is guaranteed `Some` here: `max_attempts > 1`
+                                    // only when a retry policy is set.
+                                    let delay = retry.as_ref().unwrap().delay(attempt - 1);
+                                    step_log!(
+                                        self.task_id,
+                                        index,
+                                        log::Level::Warn,
+                                        "Execution failed, retrying (attempt {}/{}) after {:?} - {}",
+                                        attempt,
+                                        max_attempts,
+                                        delay,
+                                        step
+                                    );
+                                    if !delay.is_zero() {
+                                        tokio::time::sleep(delay).await;
+                                    }
+                                    continue;
+                                }
+                                step_log!(
+                                    self.task_id,
+                                    index,
+                                    log::Level::Error,
+                                    "Execution failed - {}",
+                                    step
+                                );
+                                self.status = Status::Failed;
+                                had_error = true;
+                                break;
+                            }
+                        }
                     }
                 }
                 // Avoid underflow in case of a task without steps.
@@ -1013,5 +1155,224 @@ mod test {
         // With no repeats left, the task is retired on reschedule.
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Finished);
+    }
+
+    /// A step exceeding the configured timeout is cancelled and marks the task failed. (C1)
+    #[tokio::test(start_paused = true)]
+    async fn test_step_timeout_marks_failed() {
+        let mut task = Task::new("* * * * * * *", Some("Timeout"), None, Utc).unwrap();
+        task.timeout = Some(Duration::from_millis(50));
+        task.add_step_default(|| async {
+            // Sleeps far longer than the timeout; the paused clock auto-advances so
+            // the timeout fires without a real wall-clock wait.
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            Ok(Success)
+        });
+        task.init();
+        assert!(task.run_task().await.is_ok());
+        assert_eq!(task.status, Status::Failed);
+    }
+
+    /// A transient failure is retried and the task succeeds once a step returns Ok. (C2)
+    #[tokio::test(start_paused = true)]
+    async fn test_retry_eventually_succeeds() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+
+        let mut task = Task::new("* * * * * * *", Some("Retry ok"), None, Utc).unwrap();
+        task.retry_policy = Some(RetryPolicy::fixed(3, Duration::from_millis(10)));
+        task.add_step_default(move || {
+            let c = c.clone();
+            async move {
+                // Fail the first two attempts, succeed on the third.
+                if c.fetch_add(1, Ordering::SeqCst) < 2 {
+                    Err(Error)
+                } else {
+                    Ok(Success)
+                }
+            }
+        });
+        task.init();
+        assert!(task.run_task().await.is_ok());
+        assert_eq!(task.status, Status::Executed);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    /// When the retry budget is exhausted the task is marked failed. (C2)
+    #[tokio::test(start_paused = true)]
+    async fn test_retry_exhausted_marks_failed() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+
+        let mut task = Task::new("* * * * * * *", Some("Retry fail"), None, Utc).unwrap();
+        task.retry_policy = Some(RetryPolicy::fixed(2, Duration::from_millis(10)));
+        task.add_step_default(move || {
+            let c = c.clone();
+            async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Err(Error)
+            }
+        });
+        task.init();
+        assert!(task.run_task().await.is_ok());
+        assert_eq!(task.status, Status::Failed);
+        // 1 initial attempt + 2 retries.
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    /// `ErrorDelete` bypasses the retry policy and removes the task immediately. (C2)
+    #[tokio::test(start_paused = true)]
+    async fn test_error_delete_bypasses_retry() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+
+        let mut task = Task::new("* * * * * * *", Some("Delete"), None, Utc).unwrap();
+        task.retry_policy = Some(RetryPolicy::fixed(5, Duration::from_millis(10)));
+        task.add_step_default(move || {
+            let c = c.clone();
+            async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Err(ErrorDelete)
+            }
+        });
+        task.init();
+        assert!(task.run_task().await.is_ok());
+        assert_eq!(task.status, Status::ForceRemoved);
+        // Called exactly once — no retries.
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// A timed-out attempt counts as a retryable failure; a later attempt can succeed. (C1 + C2)
+    #[tokio::test(start_paused = true)]
+    async fn test_timeout_is_retried() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+
+        let mut task = Task::new("* * * * * * *", Some("Timeout retry"), None, Utc).unwrap();
+        task.timeout = Some(Duration::from_millis(50));
+        task.retry_policy = Some(RetryPolicy::fixed(2, Duration::from_millis(0)));
+        task.add_step_default(move || {
+            let c = c.clone();
+            async move {
+                // First attempt hangs past the timeout; subsequent attempts return quickly.
+                if c.fetch_add(1, Ordering::SeqCst) == 0 {
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+                Ok(Success)
+            }
+        });
+        task.init();
+        assert!(task.run_task().await.is_ok());
+        assert_eq!(task.status, Status::Executed);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    /// Lifecycle callbacks fire for a successful, finishing task. (C6)
+    #[tokio::test]
+    async fn test_lifecycle_callbacks_success_and_finish() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+        use tokio::sync::oneshot;
+
+        let success = Arc::new(AtomicUsize::new(0));
+        let failure = Arc::new(AtomicUsize::new(0));
+        let finish = Arc::new(AtomicUsize::new(0));
+
+        let mut task = Task::new("* * * * * * *", Some("Callbacks"), Some(1), Utc).unwrap();
+        task.add_step_default(|| async { Ok(Success) });
+
+        let s = success.clone();
+        task.on_success = Some(boxed_callback(move || {
+            let s = s.clone();
+            async move {
+                s.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+        let f = failure.clone();
+        task.on_failure = Some(boxed_callback(move || {
+            let f = f.clone();
+            async move {
+                f.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+        let fin = finish.clone();
+        task.on_finish = Some(boxed_callback(move || {
+            let fin = fin.clone();
+            async move {
+                fin.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+
+        task.set_id(0);
+        task.init();
+        // Force the task to be due.
+        task.next_exec = Some(Utc::now() - chrono::Duration::seconds(1));
+
+        // Run: fires on_success.
+        let (tx, rx) = oneshot::channel();
+        task.execute_command(TaskCmd::Run { sender: tx }).await;
+        let _ = rx.await.unwrap();
+
+        // Reschedule: repeats exhausted, so the task finishes and fires on_finish.
+        let (tx, rx) = oneshot::channel();
+        task.execute_command(TaskCmd::Reschedule { sender: tx })
+            .await;
+        let _ = rx.await.unwrap();
+
+        assert_eq!(success.load(Ordering::SeqCst), 1);
+        assert_eq!(failure.load(Ordering::SeqCst), 0);
+        assert_eq!(finish.load(Ordering::SeqCst), 1);
+    }
+
+    /// A force-removed task fires both on_failure and on_finish. (C6)
+    #[tokio::test]
+    async fn test_lifecycle_callbacks_force_removed() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+        use tokio::sync::oneshot;
+
+        let failure = Arc::new(AtomicUsize::new(0));
+        let finish = Arc::new(AtomicUsize::new(0));
+
+        let mut task = Task::new("* * * * * * *", Some("Callbacks delete"), None, Utc).unwrap();
+        task.add_step_default(|| async { Err(ErrorDelete) });
+
+        let f = failure.clone();
+        task.on_failure = Some(boxed_callback(move || {
+            let f = f.clone();
+            async move {
+                f.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+        let fin = finish.clone();
+        task.on_finish = Some(boxed_callback(move || {
+            let fin = fin.clone();
+            async move {
+                fin.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+
+        task.set_id(0);
+        task.init();
+        task.next_exec = Some(Utc::now() - chrono::Duration::seconds(1));
+
+        let (tx, rx) = oneshot::channel();
+        task.execute_command(TaskCmd::Run { sender: tx }).await;
+        let _ = rx.await.unwrap();
+
+        assert_eq!(failure.load(Ordering::SeqCst), 1);
+        assert_eq!(finish.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
- Added drift-free scheduler polling: run()/run_until() now drive on a tokio Interval (MissedTickBehavior::Skip) instead of a fixed post-round sleep, so the poll cadence no longer accumulates each round's execution time
- Added optional per-step execution timeout via TaskBuilder::timeout(); a step exceeding it is cancelled and treated as a retryable failure
- Added retry/backoff support: new RetryPolicy and Backoff (fixed and exponential with an optional max delay) applied via TaskBuilder::retry(); ErrorDelete still bypasses retries
- Added async lifecycle callbacks via TaskBuilder::on_success/on_failure/on_finish; on_finish fires once when the task reaches a terminal state
- Exported RetryPolicy and Backoff from the crate root and added the `retry` module
- Added examples/retry_timeout_example.rs showcasing timeouts, retries and lifecycle callbacks
- Updated README (timeouts/retries/callbacks section) and crate-level docs
- Added unit tests for step timeouts, retry (eventual success, exhaustion, ErrorDelete bypass) and lifecycle callbacks
- Bumped version to 0.3.1