### PR TITLE
release: v0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tasklet"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Stavros Grigoriou <unix121@protonmail.com>"]
 edition = "2021"
 rust-version = "1.90.0"
@@ -18,8 +18,9 @@ log = "0.4.29"
 # Notify, timers and the `select!`/`pin!` macros. Downstream crates can enable
 # more features themselves.
 tokio = { version = "1.48.0", features = ["rt", "sync", "time", "macros"] }
-futures = "0.3.31"
 thiserror = "2.0.17"
+# Small, dependency-free PRNG used only for retry backoff jitter.
+fastrand = "2.3"
 
 [dev-dependencies]
 simple_logger = "5.1.0"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In your `Cargo.toml` add:
 
 ```
 [dependencies]
-tasklet = "0.3.1"
+tasklet = "0.3.2"
 ```
 
 > **Upgrading from 0.2.x?** See the [migration notes](#migrating-from-02x-to-030) below —
@@ -154,12 +154,54 @@ let _task = TaskBuilder::new(chrono::Local)
 - **Timeout** (`.timeout`) bounds each individual step attempt; a step that exceeds it is
   cancelled and treated as a (retryable) failure.
 - **Retry** (`.retry`) re-attempts a step that returns `TaskStepStatusErr::Error` (or times
-  out). Use `RetryPolicy::fixed` or `RetryPolicy::exponential`. A step returning
-  `TaskStepStatusErr::ErrorDelete` bypasses retries and removes the task immediately.
+  out). Use `RetryPolicy::fixed` or `RetryPolicy::exponential`, optionally with
+  `.with_jitter(Jitter::Full)` to spread retries out and avoid a thundering herd. A step
+  returning `TaskStepStatusErr::ErrorDelete` bypasses retries and removes the task immediately.
 - **Callbacks** (`.on_success` / `.on_failure` / `.on_finish`) are async hooks;
   `on_finish` fires once when the task reaches a terminal state.
 
 See [`examples/retry_timeout_example.rs`](/examples/retry_timeout_example.rs) for a runnable demo.
+
+## Overlap policy and non-blocking scheduling
+
+Tasks run independently: a task whose step takes longer than its interval never delays
+any other task's schedule. When a task's next scheduled time arrives while its previous
+run is still in progress, the `OverlapPolicy` decides what happens (added in 0.3.2):
+
+- **`Skip`** (default): drop that occurrence and resume on the next future slot.
+- **`Queue`**: run the missed occurrence once the current run finishes.
+
+```rust,no_run
+# use tasklet::{OverlapPolicy, TaskBuilder};
+# use tasklet::task::TaskStepStatusOk::Success;
+let _task = TaskBuilder::new(chrono::Local)
+    .every("* * * * * * *")
+    .overlap(OverlapPolicy::Queue)
+    .add_step("Step", || async { Ok(Success) })
+    .build();
+```
+
+## Observing the scheduler
+
+Grab a `SchedulerHandle` with `scheduler.handle()` and query the live task set at
+runtime (added in 0.3.2):
+
+```rust,no_run
+# use tasklet::TaskScheduler;
+# #[tokio::main]
+# async fn main() {
+let scheduler = TaskScheduler::default(chrono::Utc);
+let handle = scheduler.handle();
+
+// From anywhere, e.g. a metrics endpoint:
+println!("{} task(s) live", handle.task_count());
+for state in handle.statuses() {
+    println!("task {} is {:?} (running: {})", state.id, state.status, state.running);
+}
+# }
+```
+
+See [`examples/overlap_and_status_example.rs`](/examples/overlap_and_status_example.rs) for a runnable demo.
 
 ## Migrating from 0.2.x to 0.3.0
 

--- a/examples/overlap_and_status_example.rs
+++ b/examples/overlap_and_status_example.rs
@@ -1,0 +1,84 @@
+use log::info;
+use simple_logger::SimpleLogger;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tasklet::task::TaskStepStatusOk::Success;
+use tasklet::{OverlapPolicy, TaskBuilder, TaskScheduler};
+
+/// Demonstrates two features:
+///
+/// * Overlap policy (`OverlapPolicy::Skip`): a slow task that takes longer than its
+///   interval does not start a second overlapping run, and crucially does not delay
+///   the fast task's schedule (runs are non-blocking).
+/// * Runtime status queries: a `SchedulerHandle` is polled from another task to print
+///   how many tasks are live and what their states are.
+#[tokio::main]
+async fn main() {
+    SimpleLogger::new().init().unwrap();
+
+    let slow_runs = Arc::new(AtomicUsize::new(0));
+    let fast_runs = Arc::new(AtomicUsize::new(0));
+
+    let mut scheduler = TaskScheduler::new(200, chrono::Local);
+
+    // A slow task: each run takes ~2 seconds, longer than its one-second cadence.
+    let s = slow_runs.clone();
+    let slow_task = TaskBuilder::new(chrono::Local)
+        .every("* * * * * * *")
+        .description("Slow task")
+        .overlap(OverlapPolicy::Skip) // default; shown here for clarity
+        .add_step("Slow step", move || {
+            let s = s.clone();
+            async move {
+                let n = s.fetch_add(1, Ordering::SeqCst) + 1;
+                info!("slow run #{} started, working for 2s...", n);
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                info!("slow run #{} done", n);
+                Ok(Success)
+            }
+        })
+        .build();
+    scheduler.add_task(slow_task).unwrap();
+
+    // A fast task on the same cadence; it keeps ticking regardless of the slow task.
+    let f = fast_runs.clone();
+    let fast_task = TaskBuilder::new(chrono::Local)
+        .every("* * * * * * *")
+        .description("Fast task")
+        .add_step("Fast step", move || {
+            let f = f.clone();
+            async move {
+                info!("fast run #{}", f.fetch_add(1, Ordering::SeqCst) + 1);
+                Ok(Success)
+            }
+        })
+        .build();
+    scheduler.add_task(fast_task).unwrap();
+
+    // Poll the scheduler's state from another task using the handle.
+    let handle = scheduler.handle();
+    let observer = tokio::spawn(async move {
+        for _ in 0..5 {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            let running = handle.statuses().iter().filter(|t| t.running).count();
+            info!(
+                "[status] {} task(s) live, {} currently running",
+                handle.task_count(),
+                running
+            );
+        }
+    });
+
+    // Run for a few seconds, then stop cleanly.
+    scheduler
+        .run_until(tokio::time::sleep(Duration::from_secs(5)))
+        .await;
+    observer.await.unwrap();
+
+    info!(
+        "totals: slow ran {} time(s), fast ran {} time(s)",
+        slow_runs.load(Ordering::SeqCst),
+        fast_runs.load(Ordering::SeqCst)
+    );
+}

--- a/examples/retry_timeout_example.rs
+++ b/examples/retry_timeout_example.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 use std::time::Duration;
 use tasklet::task::TaskStepStatusErr::Error;
 use tasklet::task::TaskStepStatusOk::Success;
-use tasklet::{RetryPolicy, TaskBuilder, TaskScheduler};
+use tasklet::{Jitter, RetryPolicy, TaskBuilder, TaskScheduler};
 
-/// Showcase of the resilience features added in 0.3.1:
+/// Showcase of the resilience features:
 ///
 /// * `.timeout(..)`  — bounds each individual step attempt.
-/// * `.retry(..)`    — re-attempts failing steps with a backoff policy.
+/// * `.retry(..)`    — re-attempts failing steps with a backoff policy and jitter.
 /// * `.on_success` / `.on_failure` / `.on_finish` — async lifecycle callbacks.
 ///
 /// The task runs a single time (`repeat(1)`). Its step fails on the first two
@@ -35,10 +35,12 @@ async fn main() {
             // Cancel any single attempt that runs longer than 2 seconds.
             .timeout(Duration::from_secs(2))
             // Retry up to 3 times with exponential backoff (100ms, 200ms, 400ms),
-            // capped at 1 second.
+            // capped at 1 second, with full jitter so many failing tasks don't all
+            // retry at the same instant.
             .retry(
                 RetryPolicy::exponential(3, Duration::from_millis(100), 2)
-                    .with_max_delay(Duration::from_secs(1)),
+                    .with_max_delay(Duration::from_secs(1))
+                    .with_jitter(Jitter::Full),
             )
             // Async lifecycle callbacks.
             .on_success(|| async { info!("run succeeded") })

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -1,7 +1,7 @@
 use crate::errors::{TaskError, TaskResult};
 use crate::retry::RetryPolicy;
 use crate::task::{
-    boxed_callback, CallbackFn, Task, TaskStep, TaskStepStatusErr, TaskStepStatusOk,
+    boxed_callback, CallbackFn, OverlapPolicy, Task, TaskStep, TaskStepStatusErr, TaskStepStatusOk,
 };
 use chrono::TimeZone;
 use cron::Schedule;
@@ -36,6 +36,8 @@ where
     on_failure: Option<Box<CallbackFn>>,
     /// (Optional) callback invoked once the task reaches a terminal state.
     on_finish: Option<Box<CallbackFn>>,
+    /// Behaviour when a run overlaps a still-running one.
+    overlap: OverlapPolicy,
     /// The Task/Scheduler timezone.
     timezone: T,
 }
@@ -68,6 +70,7 @@ where
             on_success: None,
             on_failure: None,
             on_finish: None,
+            overlap: OverlapPolicy::default(),
             timezone,
         }
     }
@@ -177,6 +180,28 @@ where
     /// ```
     pub fn retry(mut self, policy: RetryPolicy) -> TaskBuilder<T> {
         self.retry_policy = Some(policy);
+        self
+    }
+
+    /// Set the overlap policy: what to do when a scheduled run comes due while a
+    /// previous run of this task is still in progress.
+    ///
+    /// # Arguments
+    ///
+    /// * overlap   - The [`OverlapPolicy`] to apply (defaults to `Skip`).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tasklet::{OverlapPolicy, TaskBuilder};
+    /// let _task = TaskBuilder::new(chrono::Local)
+    ///     .every("* * * * * * *")
+    ///     .overlap(OverlapPolicy::Queue)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn overlap(mut self, overlap: OverlapPolicy) -> TaskBuilder<T> {
+        self.overlap = overlap;
         self
     }
 
@@ -348,6 +373,7 @@ where
         if let Some(policy) = self.retry_policy {
             task.set_retry_policy(policy);
         }
+        task.set_overlap(self.overlap);
 
         // Transfer the lifecycle callbacks.
         task.set_callbacks(self.on_success, self.on_failure, self.on_finish);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,14 @@
 //!   [`TaskScheduler::handle`] before running and call `shutdown()` to stop the scheduler
 //!   cleanly, or drive shutdown with any future via [`TaskScheduler::run_until`].
 //! * **Resilience** — configure a per-step [`TaskBuilder::timeout`], a
-//!   [`RetryPolicy`] via [`TaskBuilder::retry`], and async lifecycle
-//!   callbacks ([`TaskBuilder::on_success`] / [`on_failure`](TaskBuilder::on_failure) /
-//!   [`on_finish`](TaskBuilder::on_finish)).
+//!   [`RetryPolicy`] (with optional [`Jitter`]) via [`TaskBuilder::retry`], and async
+//!   lifecycle callbacks ([`TaskBuilder::on_success`] /
+//!   [`on_failure`](TaskBuilder::on_failure) / [`on_finish`](TaskBuilder::on_finish)).
+//! * **Non-blocking scheduling** — a slow task never delays other tasks. Control what
+//!   happens when a run overruns its interval with an [`OverlapPolicy`] via
+//!   [`TaskBuilder::overlap`].
+//! * **Observability** — query the live task set at runtime through
+//!   [`SchedulerHandle::task_count`] / [`SchedulerHandle::statuses`].
 //!
 //! # Example
 //!
@@ -46,9 +51,9 @@ pub mod task;
 pub use builders::TaskBuilder;
 pub use errors::{TaskError, TaskResult};
 pub use generator::TaskGenerator;
-pub use retry::{Backoff, RetryPolicy};
-pub use scheduler::{SchedulerHandle, TaskScheduler};
-pub use task::Task;
+pub use retry::{Backoff, Jitter, RetryPolicy};
+pub use scheduler::{SchedulerHandle, TaskScheduler, TaskState};
+pub use task::{OverlapPolicy, Status, Task};
 
 /// Macro for consistent task-related logging
 ///

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -9,6 +9,44 @@
 
 use std::time::Duration;
 
+/// Randomized spread applied on top of the computed backoff delay.
+///
+/// Jitter avoids a "thundering herd" where many tasks that failed at the same
+/// instant all retry at exactly the same time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Jitter {
+    /// No jitter; use the computed delay exactly.
+    #[default]
+    None,
+    /// Pick a delay uniformly in `[0, computed]`.
+    Full,
+    /// Pick a delay uniformly in `[computed / 2, computed]`.
+    Equal,
+}
+
+impl Jitter {
+    /// Apply the jitter strategy to a computed backoff `delay`.
+    fn apply(self, delay: Duration) -> Duration {
+        match self {
+            Jitter::None => delay,
+            Jitter::Full => {
+                let nanos = clamp_nanos(delay);
+                Duration::from_nanos(fastrand::u64(0..=nanos))
+            }
+            Jitter::Equal => {
+                let half = clamp_nanos(delay) / 2;
+                Duration::from_nanos(half + fastrand::u64(0..=half))
+            }
+        }
+    }
+}
+
+/// Clamp a duration to a `u64` nanosecond count (durations this large never occur
+/// in practice, but this keeps the conversion total).
+fn clamp_nanos(delay: Duration) -> u64 {
+    delay.as_nanos().min(u64::MAX as u128) as u64
+}
+
 /// The delay strategy applied between retry attempts.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Backoff {
@@ -46,6 +84,8 @@ pub struct RetryPolicy {
     pub max_retries: usize,
     /// The backoff strategy applied between attempts.
     pub backoff: Backoff,
+    /// The randomized spread applied on top of the computed delay.
+    pub jitter: Jitter,
 }
 
 impl RetryPolicy {
@@ -67,6 +107,7 @@ impl RetryPolicy {
         RetryPolicy {
             max_retries,
             backoff: Backoff::Fixed(delay),
+            jitter: Jitter::None,
         }
     }
 
@@ -95,6 +136,7 @@ impl RetryPolicy {
                 factor,
                 max: None,
             },
+            jitter: Jitter::None,
         }
     }
 
@@ -115,7 +157,24 @@ impl RetryPolicy {
         self
     }
 
-    /// Compute the delay to wait before the retry at the given (0-indexed) position.
+    /// Apply a [`Jitter`] strategy to spread retries out in time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// # use tasklet::retry::Jitter;
+    /// # use tasklet::RetryPolicy;
+    /// let _ = RetryPolicy::exponential(4, Duration::from_millis(100), 2)
+    ///     .with_jitter(Jitter::Full);
+    /// ```
+    pub fn with_jitter(mut self, jitter: Jitter) -> Self {
+        self.jitter = jitter;
+        self
+    }
+
+    /// Compute the deterministic backoff delay before the retry at the given
+    /// (0-indexed) position, ignoring jitter.
     ///
     /// Overflow-safe: an exponential delay that would overflow saturates rather than
     /// panicking.
@@ -132,6 +191,12 @@ impl RetryPolicy {
                 }
             }
         }
+    }
+
+    /// The actual delay to sleep before the given retry, including any configured
+    /// jitter. This is what the scheduler uses at runtime.
+    pub(crate) fn jittered_delay(&self, retry_index: u32) -> Duration {
+        self.jitter.apply(self.delay(retry_index))
     }
 }
 
@@ -182,5 +247,52 @@ mod test {
         let policy = RetryPolicy::fixed(2, Duration::from_millis(50))
             .with_max_delay(Duration::from_millis(10));
         assert_eq!(policy.delay(0), Duration::from_millis(50));
+    }
+
+    #[test]
+    fn jitter_defaults_to_none() {
+        let policy = RetryPolicy::fixed(2, Duration::from_millis(100));
+        assert_eq!(policy.jitter, Jitter::None);
+        // Without jitter, the runtime delay equals the deterministic base.
+        assert_eq!(policy.jittered_delay(0), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn full_jitter_stays_within_bounds() {
+        fastrand::seed(42);
+        let base = Duration::from_millis(100);
+        let policy = RetryPolicy::fixed(3, base).with_jitter(Jitter::Full);
+        for _ in 0..1000 {
+            let d = policy.jittered_delay(0);
+            assert!(d <= base, "full jitter must not exceed the base delay");
+        }
+    }
+
+    #[test]
+    fn equal_jitter_stays_within_bounds() {
+        fastrand::seed(7);
+        let base = Duration::from_millis(100);
+        let policy = RetryPolicy::exponential(3, base, 2).with_jitter(Jitter::Equal);
+        for _ in 0..1000 {
+            // retry_index 1 => base * 2 = 200ms; equal jitter => [100ms, 200ms].
+            let d = policy.jittered_delay(1);
+            assert!(
+                d >= Duration::from_millis(100) && d <= Duration::from_millis(200),
+                "equal jitter out of bounds: {:?}",
+                d
+            );
+        }
+    }
+
+    #[test]
+    fn jitter_produces_varied_values() {
+        fastrand::seed(123);
+        let policy = RetryPolicy::fixed(3, Duration::from_millis(100)).with_jitter(Jitter::Full);
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..50 {
+            seen.insert(policy.jittered_delay(0).as_nanos());
+        }
+        // With full jitter over 50 draws we expect more than a single value.
+        assert!(seen.len() > 1, "jitter should vary the delay");
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,44 +1,52 @@
 use crate::errors::{TaskError, TaskResult};
 use crate::generator::TaskGenerator;
-use crate::task::{run_task, Status, Task, TaskCmd, TaskResponse};
+use crate::task::{run_task, OverlapPolicy, Status, Task, TaskCmd, TaskShared};
 use crate::{scheduler_log, task_log};
 use chrono::prelude::*;
 use chrono::Utc;
-use futures::future::join_all;
-use futures::StreamExt;
 use std::future::Future;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::{mpsc, oneshot, Notify};
+use tokio::sync::{mpsc, Notify};
 use tokio::task::JoinHandle;
 
-/// Task execution possible statuses.
-#[derive(Debug, PartialEq)]
-pub(crate) enum ExecutionStatus {
-    Success(usize),
-    NoExecution,
-    HadError(usize, usize),
-}
-
-/// Handler for task threads.
-/// Contains the join handle and sender for each task.
+/// Handler for a running task.
 ///
-/// When a task is finished the handle must be destroyed and sender dropped, in order to totally remove the task from the execution context.
-///
-/// The #id must be set upon the task initialization in order to be easier to query for later use.
+/// Holds the task's join handle, the sender used to dispatch runs, and the shared
+/// state the task publishes so the scheduler can observe it without a blocking
+/// request/response round-trip.
 #[derive(Debug)]
 pub struct TaskHandle {
     id: usize,
     handle: JoinHandle<()>,
     sender: mpsc::Sender<TaskCmd>,
-    is_init: bool,
+    shared: Arc<TaskShared>,
+    overlap: OverlapPolicy,
 }
 
-/// A cloneable handle used to control a running [`TaskScheduler`].
+/// A snapshot of a single task's state, as reported by [`SchedulerHandle`].
+///
+/// This is a read-only view refreshed at the end of every scheduler round.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct TaskState {
+    /// The task's id, as assigned by the scheduler.
+    pub id: usize,
+    /// The task's lifecycle status as of the last completed round.
+    pub status: Status,
+    /// The task's next execution time, normalized to UTC (`None` if not scheduled).
+    pub next_exec: Option<DateTime<Utc>>,
+    /// Whether a run of this task is currently in progress.
+    pub running: bool,
+}
+
+/// A cloneable handle used to control and observe a running [`TaskScheduler`].
 ///
 /// Obtain one with [`TaskScheduler::handle`] *before* calling
 /// [`TaskScheduler::run`], then call [`SchedulerHandle::shutdown`] from anywhere
-/// (another task, a signal handler, etc.) to request a graceful stop.
+/// (another task, a signal handler, etc.) to request a graceful stop, or query the
+/// live task set with [`SchedulerHandle::task_count`] / [`SchedulerHandle::statuses`].
 ///
 /// # Examples
 ///
@@ -60,6 +68,7 @@ pub struct TaskHandle {
 #[derive(Clone, Debug)]
 pub struct SchedulerHandle {
     notify: Arc<Notify>,
+    status: Arc<Mutex<Vec<TaskState>>>,
 }
 
 impl SchedulerHandle {
@@ -73,6 +82,28 @@ impl SchedulerHandle {
         // `notify_one` stores a permit if there is no current waiter, so a shutdown
         // requested before `run()` reaches its await point is not lost.
         self.notify.notify_one();
+    }
+
+    /// The number of tasks currently registered with the scheduler.
+    ///
+    /// The value reflects the most recently completed round.
+    pub fn task_count(&self) -> usize {
+        self.status.lock().unwrap().len()
+    }
+
+    /// A snapshot of every live task's [`TaskState`], as of the last completed round.
+    pub fn statuses(&self) -> Vec<TaskState> {
+        self.status.lock().unwrap().clone()
+    }
+
+    /// The [`Status`] of the task with the given id, if it is still registered.
+    pub fn status_of(&self, id: usize) -> Option<Status> {
+        self.status
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|t| t.id == id)
+            .map(|t| t.status.clone())
     }
 }
 
@@ -93,6 +124,9 @@ where
     timezone: T,
     /// Notified when a graceful shutdown is requested.
     shutdown: Arc<Notify>,
+    /// Snapshot of the live tasks' states, refreshed each round and read by
+    /// [`SchedulerHandle`].
+    status: Arc<Mutex<Vec<TaskState>>>,
 }
 
 /// `TaskScheduler` implementation.
@@ -122,6 +156,7 @@ where
             timezone,
             next_id: 0,
             shutdown: Arc::new(Notify::new()),
+            status: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -137,6 +172,7 @@ where
     pub fn handle(&self) -> SchedulerHandle {
         SchedulerHandle {
             notify: self.shutdown.clone(),
+            status: self.status.clone(),
         }
     }
 
@@ -204,18 +240,23 @@ where
     ) -> Result<&mut TaskScheduler<T>, TaskError> {
         match task {
             Ok(mut task) => {
-                let (sender, receiver) = mpsc::channel(32);
+                // A buffer of one is enough: the scheduler only dispatches a run when
+                // the task is idle, so at most one `Run` is ever in flight.
+                let (sender, receiver) = mpsc::channel(1);
 
                 task.set_receiver(receiver);
                 task.set_id(self.next_id);
-                let handle = tokio::spawn(run_task(task));
+                let overlap = task.overlap;
+                let shared = Arc::new(TaskShared::new());
+                let handle = tokio::spawn(run_task(task, shared.clone()));
 
                 // Push the handle
                 self.handles.push(TaskHandle {
                     id: self.next_id,
                     handle,
                     sender,
-                    is_init: false,
+                    shared,
+                    overlap,
                 });
 
                 // Increase the id of the next task.
@@ -226,143 +267,72 @@ where
         }
     }
 
-    /// Execute all the tasks in the queue.
+    /// Run a single scheduling round.
     ///
-    /// After the execution the tasks are rescheduled and if needed,
-    /// removed from the list.
-    pub(crate) async fn execute_tasks(&mut self) -> ExecutionStatus {
-        let mut receivers: Vec<oneshot::Receiver<TaskResponse>> = Vec::new();
+    /// Reaps any task that has reached a terminal state, then dispatches a run to
+    /// every task whose next execution time is due. Dispatch is fire-and-forget: the
+    /// scheduler never waits for a task's run to complete, so a slow task cannot
+    /// delay any other task's schedule. The overlap policy decides what to do when a
+    /// task is still running at its next due time.
+    fn dispatch_round(&mut self) {
+        let now = Utc::now();
 
-        for handle in &self.handles {
-            let (sender, recv) = oneshot::channel();
-            let _ = handle.sender.send(TaskCmd::Run { sender }).await;
-            receivers.push(recv);
-        }
-
-        let err_no: Arc<Mutex<usize>> = Arc::new(Mutex::new(0usize));
-        let total_runs: Arc<Mutex<usize>> = Arc::new(Mutex::new(0usize));
-        futures::stream::iter(receivers)
-            .for_each(|r| async {
-                // A task whose sender was dropped (e.g. it panicked) yields a
-                // `RecvError`; log and skip it rather than bringing down the scheduler.
-                let status = match r.await {
-                    Ok(response) => response.status,
-                    Err(_) => {
-                        scheduler_log!(
-                            log::Level::Error,
-                            "A task failed to report its run status and will be skipped"
-                        );
-                        return;
-                    }
-                };
-                match status {
-                    Status::Executed => {
-                        *total_runs.lock().unwrap() += 1;
-                    }
-                    Status::Failed => {
-                        *err_no.lock().unwrap() += 1;
-                        *total_runs.lock().unwrap() += 1;
-                    }
-                    _ => { /* Do nothing */ }
-                };
-            })
-            .await;
-
-        // Send for reschedule
-        receivers = Vec::new();
-        for handle in &self.handles {
-            let (send, recv) = oneshot::channel();
-            let _ = handle
-                .sender
-                .send(TaskCmd::Reschedule { sender: send })
-                .await;
-            receivers.push(recv);
-        }
-
-        for recv in receivers {
-            let res = match recv.await {
-                Ok(res) => res,
-                Err(_) => {
-                    scheduler_log!(
-                        log::Level::Error,
-                        "A task failed to report its reschedule status and will be skipped"
-                    );
-                    continue;
-                }
-            };
-            if res.status == Status::Finished || res.status == Status::ForceRemoved {
-                for handle in &self.handles {
-                    if handle.id == res.id {
-                        task_log!(
-                            res.id,
-                            log::Level::Debug,
-                            "Removing task due to {}",
-                            if res.status == Status::Finished {
-                                "end of execution cycle"
-                            } else {
-                                "force removal"
-                            }
-                        );
-                        handle.handle.abort();
-                    }
-                }
-                let index = self.handles.iter().position(|x| x.id == res.id).unwrap();
-                self.handles.remove(index);
-            }
-        }
-
-        // Build the response
-        if *total_runs.lock().unwrap() > 0 {
-            if *err_no.lock().unwrap() == 0 {
-                ExecutionStatus::Success(*total_runs.lock().unwrap())
+        // Reap tasks that have reached a terminal state and published `finished`.
+        self.handles.retain(|handle| {
+            if handle.shared.finished.load(Ordering::SeqCst) {
+                task_log!(handle.id, log::Level::Debug, "Removing finished task");
+                handle.handle.abort();
+                false
             } else {
-                ExecutionStatus::HadError(*total_runs.lock().unwrap(), *err_no.lock().unwrap())
+                true
             }
-        } else {
-            ExecutionStatus::NoExecution
+        });
+
+        // Dispatch due tasks.
+        for handle in &self.handles {
+            let due = match handle.shared.state.lock().unwrap().next_exec {
+                Some(next) => now >= next,
+                None => false,
+            };
+            if !due {
+                continue;
+            }
+
+            if handle.shared.running.load(Ordering::SeqCst) {
+                // A previous run is still in progress: apply the overlap policy.
+                match handle.overlap {
+                    OverlapPolicy::Skip => { /* drop this occurrence */ }
+                    OverlapPolicy::Queue => {
+                        handle.shared.pending.store(true, Ordering::SeqCst);
+                    }
+                }
+            } else {
+                // Fire-and-forget. `try_send` never blocks; a full channel means a run
+                // is already queued for this idle task, so dropping the duplicate is
+                // the correct behaviour.
+                let _ = handle.sender.try_send(TaskCmd::Run);
+            }
         }
+
+        self.refresh_status();
     }
 
-    /// Send an init signal to all the tasks that are not yet initialized.
-    pub(crate) async fn init_tasks(&mut self) {
-        let mut receivers: Vec<oneshot::Receiver<TaskResponse>> = Vec::new();
-        let mut count: usize = 0;
-
-        // Send init signal to all the tasks that are not initialized yet.
-        for handle in &self.handles {
-            if !handle.is_init {
-                let (sender, recv) = oneshot::channel();
-                let _ = handle.sender.send(TaskCmd::Init { sender }).await;
-                receivers.push(recv);
-                count += 1;
-            }
-        }
-
-        if count > 0 {
-            // Await for all receivers to finish
-            join_all(receivers).await.iter().for_each(|r| match r {
-                Ok(r) => match r.status {
-                    Status::Scheduled => {
-                        self.handles
-                            .iter_mut()
-                            .filter(|h| h.id == r.id)
-                            .for_each(|h| {
-                                task_log!(h.id, log::Level::Info, "Initialized");
-                                h.is_init = true;
-                            });
-                    }
-                    _ => {
-                        task_log!(r.id, log::Level::Error, "Failed to initialize");
-                    }
-                },
-                Err(_) => {
-                    scheduler_log!(
-                        log::Level::Error,
-                        "A task failed to report its init status and will be skipped"
-                    );
+    /// Refresh the observable status snapshot from every live task's shared state.
+    fn refresh_status(&self) {
+        let snapshot = self
+            .handles
+            .iter()
+            .map(|handle| {
+                let state = handle.shared.state.lock().unwrap();
+                TaskState {
+                    id: handle.id,
+                    status: state.status.clone(),
+                    next_exec: state.next_exec,
+                    running: handle.shared.running.load(Ordering::SeqCst),
                 }
-            });
-        }
+            })
+            .collect();
+        *self.status.lock().unwrap() = snapshot;
     }
 
     /// Execute the `TaskGenerator` instance (if set).
@@ -398,31 +368,11 @@ where
         self.handles.clear();
     }
 
-    /// Run one iteration of the scheduler flow: run the generator (if due),
-    /// (re)initialize tasks and execute the current round.
-    async fn tick(&mut self) {
-        if self.run_task_gen() {
-            // Re-initialize the tasks if any new is added
-            self.init_tasks().await;
-        }
-        match self.execute_tasks().await {
-            ExecutionStatus::Success(c) => {
-                scheduler_log!(
-                    log::Level::Info,
-                    "Execution round completed successfully for {} task(s)",
-                    c
-                );
-            }
-            ExecutionStatus::HadError(c, e) => {
-                scheduler_log!(
-                    log::Level::Error,
-                    "Execution round ran {} task(s) with {} error(s)",
-                    c,
-                    e
-                );
-            }
-            _ => { /* No executions */ }
-        }
+    /// Run one iteration of the scheduler flow: run the generator (if due) and
+    /// dispatch the current round. Newly generated tasks initialize themselves.
+    fn tick(&mut self) {
+        self.run_task_gen();
+        self.dispatch_round();
     }
 
     /// Main execution loop.
@@ -483,8 +433,7 @@ where
 
         tokio::pin!(shutdown);
 
-        // Initialize the tasks
-        self.init_tasks().await;
+        // Tasks initialize themselves when spawned, so there is no separate init phase.
 
         // Drive the loop with an `Interval` rather than sleeping for a fixed amount
         // *after* each round. `sleep` would add the duration of `tick()` to every
@@ -506,7 +455,7 @@ where
                     break;
                 }
                 _ = interval.tick() => {
-                    self.tick().await;
+                    self.tick();
                 }
             }
         }
@@ -519,93 +468,216 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::task::TaskStepStatusErr::{Error, ErrorDelete};
+    use crate::task::TaskStepStatusErr::ErrorDelete;
     use crate::task::TaskStepStatusOk::Success;
     use crate::TaskBuilder;
     use chrono::Local;
+    use std::sync::atomic::AtomicUsize;
     use std::time::Duration;
 
+    /// Build a task that increments `counter` once per run.
+    fn counting_task(
+        counter: &Arc<AtomicUsize>,
+        repeats: Option<usize>,
+    ) -> TaskResult<Task<Local>> {
+        let c = counter.clone();
+        let mut builder = TaskBuilder::new(Local)
+            .every("* * * * * * *")
+            .add_step_default(move || {
+                let c = c.clone();
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    Ok(Success)
+                }
+            });
+        if let Some(r) = repeats {
+            builder = builder.repeat(r);
+        }
+        builder.build()
+    }
+
+    /// A finite task runs the expected number of times and is then reaped. (X1)
     #[tokio::test]
-    async fn test_scheduler_normal_flow() {
-        // Create a new scheduler instance.
-        let mut scheduler = TaskScheduler::new(500, Local);
-        // Add a couple of tasks.
+    async fn test_scheduler_runs_finite_task_and_reaps() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut scheduler = TaskScheduler::new(100, Local);
         scheduler
-            .add_task(Task::new("* * * * * * *", None, Some(2), Local))
-            .unwrap()
+            .add_task(counting_task(&counter, Some(1)))
+            .unwrap();
+
+        let handle = scheduler.handle();
+        let observed = Arc::new(AtomicUsize::new(usize::MAX));
+        let obs = observed.clone();
+        let observer = tokio::spawn(async move {
+            // After the single run has completed, the task must be gone.
+            tokio::time::sleep(Duration::from_millis(1600)).await;
+            obs.store(handle.task_count(), Ordering::SeqCst);
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            scheduler.run_until(tokio::time::sleep(Duration::from_millis(2000))),
+        )
+        .await
+        .expect("scheduler did not stop");
+        observer.await.unwrap();
+
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "task should run exactly once"
+        );
+        assert_eq!(
+            observed.load(Ordering::SeqCst),
+            0,
+            "finished task should be reaped"
+        );
+    }
+
+    /// A slow-running task must not delay other tasks' schedules. (X1 headline)
+    #[tokio::test]
+    async fn test_slow_task_does_not_block_others() {
+        let slow = Arc::new(AtomicUsize::new(0));
+        let fast = Arc::new(AtomicUsize::new(0));
+
+        let mut scheduler = TaskScheduler::new(100, Local);
+
+        // A slow task: records that it started, then blocks for two seconds.
+        let s = slow.clone();
+        let slow_task = TaskBuilder::new(Local)
+            .every("* * * * * * *")
+            .add_step_default(move || {
+                let s = s.clone();
+                async move {
+                    s.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    Ok(Success)
+                }
+            })
+            .build();
+        scheduler.add_task(slow_task).unwrap();
+        // A fast task on the same one-second cadence.
+        scheduler.add_task(counting_task(&fast, None)).unwrap();
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            scheduler.run_until(tokio::time::sleep(Duration::from_millis(2500))),
+        )
+        .await
+        .expect("scheduler did not stop");
+
+        // The fast task keeps ticking even while the slow one is blocked.
+        assert!(
+            fast.load(Ordering::SeqCst) >= 2,
+            "fast task was blocked by the slow one: {} runs",
+            fast.load(Ordering::SeqCst)
+        );
+        // The slow task started once; Skip (default) prevents a second overlapping run.
+        assert_eq!(
+            slow.load(Ordering::SeqCst),
+            1,
+            "slow task should not overlap itself under Skip"
+        );
+    }
+
+    /// `dispatch_round` does not start a new run when one is in progress under Skip. (X1)
+    #[tokio::test]
+    async fn test_dispatch_skips_running_task() {
+        let mut scheduler = TaskScheduler::new(1000, Local);
+        scheduler
             .add_task(Task::new("* * * * * * *", None, None, Local))
             .unwrap();
-        assert_eq!(scheduler.handles.len(), 2);
-        // Initialize the tasks.
-        scheduler.init_tasks().await;
-        tokio::time::sleep(Duration::from_millis(1000)).await;
-        let status: ExecutionStatus = scheduler.execute_tasks().await;
-        assert_eq!(status, ExecutionStatus::Success(2));
-        assert_eq!(scheduler.handles.len(), 2);
-        tokio::time::sleep(Duration::from_millis(1000)).await;
-        let status: ExecutionStatus = scheduler.execute_tasks().await;
-        assert_eq!(status, ExecutionStatus::Success(2));
-        assert_eq!(scheduler.handles.len(), 1);
+        // Allow the task to self-initialize.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Simulate a due task whose previous run is still in progress.
+        {
+            let shared = &scheduler.handles[0].shared;
+            shared.running.store(true, Ordering::SeqCst);
+            shared.state.lock().unwrap().next_exec =
+                Some(Utc::now() - chrono::Duration::seconds(1));
+        }
+        scheduler.dispatch_round();
+
+        // Skip: nothing is queued.
+        assert!(!scheduler.handles[0].shared.pending.load(Ordering::SeqCst));
     }
 
+    /// `dispatch_round` queues a missed occurrence when the policy is Queue. (X1)
     #[tokio::test]
-    async fn test_scheduler_normal_force_deletion() {
-        // Create a new scheduler instance.
-        let mut scheduler = TaskScheduler::new(500, Local);
-        // Create a task.
-        let mut task = Task::new("* * * * * * *", None, Some(1), Local).unwrap();
-        task.add_step_default(|| async { Err(ErrorDelete) });
-        // Add a couple of tasks.
-        scheduler
-            .add_task(Ok(task))
-            .unwrap()
-            .add_task(Task::new("* * * * * * *", None, None, Local))
-            .unwrap();
-        assert_eq!(scheduler.handles.len(), 2);
-        // Initialize the tasks.
-        scheduler.init_tasks().await;
-        tokio::time::sleep(Duration::from_millis(1000)).await;
-        scheduler.execute_tasks().await;
-        // The first task should be force-removed at this point
-        assert_eq!(scheduler.handles.len(), 1);
-        tokio::time::sleep(Duration::from_millis(1000)).await;
-        scheduler.execute_tasks().await;
-        assert_eq!(scheduler.handles.len(), 1);
+    async fn test_dispatch_queues_running_task() {
+        let mut scheduler = TaskScheduler::new(1000, Local);
+        let task = TaskBuilder::new(Local)
+            .every("* * * * * * *")
+            .overlap(OverlapPolicy::Queue)
+            .build();
+        scheduler.add_task(task).unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        {
+            let shared = &scheduler.handles[0].shared;
+            shared.running.store(true, Ordering::SeqCst);
+            shared.state.lock().unwrap().next_exec =
+                Some(Utc::now() - chrono::Duration::seconds(1));
+        }
+        scheduler.dispatch_round();
+
+        // Queue: the missed occurrence is recorded.
+        assert!(scheduler.handles[0].shared.pending.load(Ordering::SeqCst));
     }
 
+    /// `dispatch_round` dispatches a run to an idle, due task. (X1)
     #[tokio::test]
-    async fn test_scheduler_normal_flow_no_execution() {
-        // Create a new scheduler instance.
-        let mut scheduler = TaskScheduler::new(500, Local);
-        // Init the scheduler.
-        scheduler.init_tasks().await;
-        tokio::time::sleep(Duration::from_millis(1000)).await;
-        // Run the scheduler
-        let status: ExecutionStatus = scheduler.execute_tasks().await;
-        // No tasks should be executed.
-        assert_eq!(status, ExecutionStatus::NoExecution);
+    async fn test_dispatch_runs_idle_due_task() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut scheduler = TaskScheduler::new(1000, Local);
+        scheduler.add_task(counting_task(&counter, None)).unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Force the task due while idle.
+        scheduler.handles[0].shared.state.lock().unwrap().next_exec =
+            Some(Utc::now() - chrono::Duration::seconds(1));
+        scheduler.dispatch_round();
+
+        // Give the dispatched run a moment to execute.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
     }
 
+    /// A force-removed task is reaped without disturbing other tasks. (X1)
     #[tokio::test]
-    async fn test_scheduler_normal_flow_error_case() {
-        // Create a new scheduler instance.
-        let mut scheduler = TaskScheduler::new(500, Local);
+    async fn test_scheduler_force_removal_isolated() {
+        let survivor = Arc::new(AtomicUsize::new(0));
+        let mut scheduler = TaskScheduler::new(100, Local);
 
-        // Create a task.
-        let mut task = Task::new("* * * * * * *", None, Some(1), Local).unwrap();
-        task.add_step_default(|| async { Ok(Success) });
-        // Return an error in the second step.
-        task.add_step_default(|| async { Err(Error) });
+        let mut doomed = Task::new("* * * * * * *", None, None, Local).unwrap();
+        doomed.add_step_default(|| async { Err(ErrorDelete) });
+        scheduler.add_task(Ok(doomed)).unwrap();
+        scheduler.add_task(counting_task(&survivor, None)).unwrap();
 
-        // Add a task.
-        scheduler.add_task(Ok(task)).unwrap();
-        assert_eq!(scheduler.handles.len(), 1);
-        // Initialize the task.
-        scheduler.init_tasks().await;
-        tokio::time::sleep(Duration::from_millis(1000)).await;
-        scheduler.execute_tasks().await;
-        // The task should be removed after it's execution circle.
-        assert_eq!(scheduler.handles.len(), 0);
+        let handle = scheduler.handle();
+        let observed = Arc::new(AtomicUsize::new(usize::MAX));
+        let obs = observed.clone();
+        let observer = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(1600)).await;
+            obs.store(handle.task_count(), Ordering::SeqCst);
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            scheduler.run_until(tokio::time::sleep(Duration::from_millis(2000))),
+        )
+        .await
+        .expect("scheduler did not stop");
+        observer.await.unwrap();
+
+        // Only the surviving task remains, and it kept running.
+        assert_eq!(
+            observed.load(Ordering::SeqCst),
+            1,
+            "doomed task should be reaped"
+        );
+        assert!(survivor.load(Ordering::SeqCst) >= 1);
     }
 
     #[tokio::test]
@@ -715,5 +787,78 @@ mod test {
         .await
         .expect("run_until did not stop when its shutdown future resolved");
         assert_eq!(scheduler.handles.len(), 0);
+    }
+
+    /// The handle reports the live task count and per-task status while running. (O1)
+    #[tokio::test]
+    async fn test_handle_status_queries() {
+        let mut scheduler = TaskScheduler::new(100, Local);
+        scheduler
+            .add_task(Task::new("* * * * * * *", None, None, Local))
+            .unwrap()
+            .add_task(Task::new("* * * * * * *", None, None, Local))
+            .unwrap();
+
+        let handle = scheduler.handle();
+        // Before running, the snapshot is empty.
+        assert_eq!(handle.task_count(), 0);
+
+        let probe = handle.clone();
+        let observer = tokio::spawn(async move {
+            // Once the tasks have initialized and been observed at least once.
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            (
+                probe.task_count(),
+                probe.statuses(),
+                probe.status_of(0),
+                probe.status_of(1),
+                probe.status_of(99),
+            )
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            scheduler.run_until(tokio::time::sleep(Duration::from_millis(800))),
+        )
+        .await
+        .expect("scheduler did not stop");
+        let (count, statuses, s0, s1, s99) = observer.await.unwrap();
+
+        assert_eq!(count, 2);
+        assert_eq!(statuses.len(), 2);
+        assert!(statuses.iter().all(|t| t.status == Status::Scheduled));
+        assert!(statuses.iter().all(|t| t.next_exec.is_some()));
+        assert_eq!(s0, Some(Status::Scheduled));
+        assert_eq!(s1, Some(Status::Scheduled));
+        assert_eq!(s99, None);
+    }
+
+    /// A finished task drops out of the handle's snapshot. (O1)
+    #[tokio::test]
+    async fn test_handle_status_drops_finished_task() {
+        let mut scheduler = TaskScheduler::new(100, Local);
+        scheduler
+            .add_task(Task::new("* * * * * * *", None, Some(1), Local))
+            .unwrap();
+        let handle = scheduler.handle();
+
+        let probe = handle.clone();
+        let observed = Arc::new(AtomicUsize::new(usize::MAX));
+        let obs = observed.clone();
+        let observer = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(1600)).await;
+            obs.store(probe.task_count(), Ordering::SeqCst);
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            scheduler.run_until(tokio::time::sleep(Duration::from_millis(2000))),
+        )
+        .await
+        .expect("scheduler did not stop");
+        observer.await.unwrap();
+
+        assert_eq!(observed.load(Ordering::SeqCst), 0);
+        assert_eq!(handle.status_of(0), None);
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -10,8 +10,10 @@ use cron::Schedule;
 use std::fmt::{self, Debug};
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 
 /// Possible success status values for a step's execution.
 #[derive(Debug, Clone, PartialEq)]
@@ -147,30 +149,65 @@ pub enum Status {
     ForceRemoved,
 }
 
-/// A message response from a task
-#[derive(Debug)]
-pub(crate) struct TaskResponse {
-    /// The id of the task as set by the scheduler
-    pub id: usize,
-    /// The status after the request has been fulfilled
-    pub status: Status,
+/// What to do when a task's next scheduled time arrives while a previous run of
+/// the same task is still in progress.
+///
+/// Concurrent overlapping runs are intentionally not offered: task steps are
+/// `FnMut` (they own mutable state), so a second simultaneous invocation would alias
+/// that state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OverlapPolicy {
+    /// Skip the occurrence; the task keeps running and resumes on its next future
+    /// slot. This is the safe default.
+    #[default]
+    Skip,
+    /// Run the missed occurrence once the current run finishes (at most one queued).
+    Queue,
 }
 
+/// A command sent from the scheduler to a running task.
 #[derive(Debug)]
-/// Available commands to be sent
 pub(crate) enum TaskCmd {
-    /// Request to initialize the task
-    Init {
-        sender: oneshot::Sender<TaskResponse>,
-    },
-    /// Execute the task
-    Run {
-        sender: oneshot::Sender<TaskResponse>,
-    },
-    /// Request the rescheduling of the task
-    Reschedule {
-        sender: oneshot::Sender<TaskResponse>,
-    },
+    /// Execute the task once now.
+    Run,
+}
+
+/// State a running task publishes so the scheduler can observe it and decide when
+/// to dispatch the next run without a blocking request/response round-trip.
+#[derive(Debug)]
+pub(crate) struct TaskShared {
+    /// True while a run is in progress.
+    pub(crate) running: AtomicBool,
+    /// Set when a due occurrence was missed while running (used by [`OverlapPolicy::Queue`]).
+    pub(crate) pending: AtomicBool,
+    /// Set once the task reaches a terminal state so the scheduler reaps it.
+    pub(crate) finished: AtomicBool,
+    /// The observable lifecycle state (status + next execution time, in UTC).
+    pub(crate) state: Mutex<SharedState>,
+}
+
+/// The observable, timezone-erased portion of a task's state.
+#[derive(Debug, Clone)]
+pub(crate) struct SharedState {
+    /// The task's current lifecycle status.
+    pub(crate) status: Status,
+    /// The task's next execution time, normalized to UTC (`None` if not scheduled).
+    pub(crate) next_exec: Option<DateTime<Utc>>,
+}
+
+impl TaskShared {
+    /// Create a fresh shared-state cell for an uninitialized task.
+    pub(crate) fn new() -> Self {
+        TaskShared {
+            running: AtomicBool::new(false),
+            pending: AtomicBool::new(false),
+            finished: AtomicBool::new(false),
+            state: Mutex::new(SharedState {
+                status: Status::Init,
+                next_exec: None,
+            }),
+        }
+    }
 }
 
 /// A structure that contains the basic information of the job.
@@ -207,6 +244,8 @@ where
     pub(crate) on_failure: Option<Box<CallbackFn>>,
     /// (Optional) callback invoked once when the task reaches a terminal state.
     pub(crate) on_finish: Option<Box<CallbackFn>>,
+    /// Behaviour when a scheduled run overlaps a still-running one.
+    pub(crate) overlap: OverlapPolicy,
 }
 
 impl<T> Debug for Task<T>
@@ -280,6 +319,7 @@ where
             on_success: None,
             on_failure: None,
             on_finish: None,
+            overlap: OverlapPolicy::default(),
         })
     }
 
@@ -370,6 +410,12 @@ where
         self
     }
 
+    /// Set the overlap policy.
+    pub(crate) fn set_overlap(&mut self, overlap: OverlapPolicy) -> &mut Task<T> {
+        self.overlap = overlap;
+        self
+    }
+
     /// Set the callbacks invoked over the task's lifecycle.
     pub(crate) fn set_callbacks(
         &mut self,
@@ -417,68 +463,40 @@ where
         }
     }
 
-    /// Create a `TaskResponse` from the current state of the task.
-    fn get_task_response(&self) -> TaskResponse {
-        TaskResponse {
-            id: self.task_id,
-            status: self.status.clone(),
+    /// Run the task's steps and fire the success/failure callbacks based on the
+    /// outcome. `on_finish` is fired here only for the terminal `ForceRemoved` state
+    /// (a normally-finishing task fires it from [`Task::reschedule_and_notify`]).
+    pub(crate) async fn run_and_notify(&mut self) {
+        let _ = self.run_task().await; // status is updated in place; the result is redundant
+        match self.status {
+            Status::Executed => Self::fire_callback(&mut self.on_success).await,
+            Status::Failed => Self::fire_callback(&mut self.on_failure).await,
+            Status::ForceRemoved => {
+                Self::fire_callback(&mut self.on_failure).await;
+                Self::fire_callback(&mut self.on_finish).await;
+            }
+            _ => {}
         }
     }
 
-    /// Execute a command sent by the scheduler.
-    ///
-    /// Each of the commands triggers the underlying method of the task,
-    /// and responds with the id of the task and the status of the task after the execution
-    /// of the command has finished.
-    pub(crate) async fn execute_command(&mut self, msg: TaskCmd) {
-        match msg {
-            TaskCmd::Run { sender } => {
-                // Only run if the task has been scheduled (has a next execution time)
-                // and that time is due. A missing `next_exec` means the task was never
-                // initialized; skip it gracefully instead of panicking.
-                //
-                // The comparison is scoped so the borrow of `next_exec` is released
-                // before the `.await`, keeping the resulting future `Send`.
-                let due = match &self.next_exec {
-                    Some(next_exec) => {
-                        *next_exec <= Utc::now().with_timezone(&self.timezone.clone())
-                    }
-                    None => false,
-                };
-                if due {
-                    let _ = self.run_task().await; // Ignore the result as we already update the status
-                                                   // Fire the relevant lifecycle callbacks based on the outcome.
-                                                   // `on_finish` for a force-removed task is fired here since that
-                                                   // is its terminal state; a normally-finishing task fires it in
-                                                   // the reschedule branch below.
-                    match self.status {
-                        Status::Executed => Self::fire_callback(&mut self.on_success).await,
-                        Status::Failed => Self::fire_callback(&mut self.on_failure).await,
-                        Status::ForceRemoved => {
-                            Self::fire_callback(&mut self.on_failure).await;
-                            Self::fire_callback(&mut self.on_finish).await;
-                        }
-                        _ => {}
-                    }
-                }
-                let _ = sender.send(self.get_task_response());
-            }
-            TaskCmd::Reschedule { sender } => {
-                let _ = self.reschedule(); // Ignore the result as we already update the status
-                                           // A task that has just reached the `Finished` state fires `on_finish`
-                                           // exactly once (force-removed tasks already fired it in the Run branch).
-                if self.status == Status::Finished {
-                    Self::fire_callback(&mut self.on_finish).await;
-                }
-                let _ = sender.send(self.get_task_response());
-            }
-            TaskCmd::Init { sender } => {
-                if self.status == Status::Init {
-                    self.init();
-                }
-                let _ = sender.send(self.get_task_response());
-            }
+    /// Reschedule the task and fire `on_finish` if it has just reached the
+    /// `Finished` state (exactly once; force-removed tasks fire it from
+    /// [`Task::run_and_notify`]).
+    pub(crate) async fn reschedule_and_notify(&mut self) {
+        let _ = self.reschedule(); // status is updated in place; the result is redundant
+        if self.status == Status::Finished {
+            Self::fire_callback(&mut self.on_finish).await;
         }
+    }
+
+    /// Whether the task has reached a terminal state and should be reaped.
+    pub(crate) fn is_terminal(&self) -> bool {
+        matches!(self.status, Status::Finished | Status::ForceRemoved)
+    }
+
+    /// The next execution time normalized to UTC, for the observable snapshot.
+    pub(crate) fn next_exec_utc(&self) -> Option<DateTime<Utc>> {
+        self.next_exec.as_ref().map(|d| d.with_timezone(&Utc))
     }
 
     /// Run the task and handle the output.
@@ -573,7 +591,7 @@ where
                                 if (attempt as usize) < max_attempts {
                                     // `retry` is guaranteed `Some` here: `max_attempts > 1`
                                     // only when a retry policy is set.
-                                    let delay = retry.as_ref().unwrap().delay(attempt - 1);
+                                    let delay = retry.as_ref().unwrap().jittered_delay(attempt - 1);
                                     step_log!(
                                         self.task_id,
                                         index,
@@ -669,37 +687,73 @@ where
     }
 }
 
-/// Wrap a `Task` around a receiver, each time a command is received, forward it to the task.
-///
-/// # Arguments
-///
-/// * task  - the task to run in the background
-///
-/// # Examples
-///
-/// ```
-/// # use chrono::Utc;
-/// # use tasklet::task::Task;
-/// # use tasklet::task::run_task;
-/// # tokio_test::block_on( async {
-/// let t = Task::new("* * * * * *", None, None, Utc).unwrap();
-/// let h = tokio::spawn(run_task(t));
-/// # h.abort();
-/// # })
-/// ```
-pub async fn run_task<T>(mut task: Task<T>)
+/// Publish the task's current status and next execution time to the shared cell
+/// the scheduler observes.
+fn publish<T>(task: &Task<T>, shared: &TaskShared)
+where
+    T: TimeZone + Send + 'static,
+{
+    let mut state = shared.state.lock().unwrap();
+    state.status = task.status.clone();
+    state.next_exec = task.next_exec_utc();
+}
+
+/// Execute the task once, fire its lifecycle callbacks, reschedule it and republish
+/// the resulting state. Marks the shared `running` flag around the work and the
+/// `finished` flag if the task became terminal.
+async fn run_once<T>(task: &mut Task<T>, shared: &TaskShared)
 where
     T: TimeZone + Send + 'static,
     <T as TimeZone>::Offset: Send,
 {
-    while let Some(msg) = task
+    shared.running.store(true, Ordering::SeqCst);
+    task.run_and_notify().await;
+    task.reschedule_and_notify().await;
+    shared.running.store(false, Ordering::SeqCst);
+    if task.is_terminal() {
+        shared.finished.store(true, Ordering::SeqCst);
+    }
+    publish(task, shared);
+}
+
+/// Drive a `Task` in its own Tokio task.
+///
+/// The task initializes itself, publishes its state to `shared`, then runs once for
+/// each [`TaskCmd::Run`] the scheduler dispatches. Runs never block the scheduler:
+/// the scheduler fire-and-forgets `Run` and observes progress through `shared`. When
+/// a run is queued via [`OverlapPolicy::Queue`], it is drained here once the current
+/// run finishes.
+pub(crate) async fn run_task<T>(mut task: Task<T>, shared: Arc<TaskShared>)
+where
+    T: TimeZone + Send + 'static,
+    <T as TimeZone>::Offset: Send,
+{
+    // Self-initialize and publish the first scheduled time.
+    task.init();
+    publish(&task, &shared);
+    if task.is_terminal() {
+        shared.finished.store(true, Ordering::SeqCst);
+        return;
+    }
+
+    let mut receiver = task
         .receiver
-        .as_mut()
-        .expect("Failed to borrow receiver.")
-        .recv()
-        .await
-    {
-        task.execute_command(msg).await;
+        .take()
+        .expect("run_task requires a receiver to be set");
+
+    while let Some(TaskCmd::Run) = receiver.recv().await {
+        run_once(&mut task, &shared).await;
+        if shared.finished.load(Ordering::SeqCst) {
+            break;
+        }
+        // `OverlapPolicy::Queue`: run any occurrence that came due while we were
+        // busy, one at a time, until none remain or the task retires.
+        while shared.pending.swap(false, Ordering::SeqCst) && !task.is_terminal() {
+            run_once(&mut task, &shared).await;
+            if shared.finished.load(Ordering::SeqCst) {
+                break;
+            }
+        }
     }
 }
 
@@ -922,62 +976,51 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_task_command_execution() {
-        use chrono::Duration;
-        use tokio::sync::oneshot;
-
-        let mut task = Task::new("* * * * * * *", Some("Command test"), Some(1), Utc).unwrap();
+    async fn test_run_and_reschedule_notify() {
+        let mut task = Task::new("* * * * * * *", Some("Notify flow"), Some(1), Utc).unwrap();
         task.set_id(1);
-
-        // Add a simple step to ensure the Run command works properly
         task.add_step("Test step", || async { Ok(TaskStepStatusOk::Success) });
 
-        // Test Init command first - this should initialize the task
-        let (tx_init, rx_init) = oneshot::channel();
-        task.execute_command(TaskCmd::Init { sender: tx_init })
-            .await;
-        let init_response = rx_init.await.unwrap();
-        assert_eq!(init_response.id, 1);
-        assert_eq!(init_response.status, Status::Scheduled);
+        task.init();
+        assert_eq!(task.status, Status::Scheduled);
 
-        // Set next_exec to a future time to prevent automatic execution
-        let future_time = Utc::now() + Duration::seconds(10);
-        task.next_exec = Some(future_time);
+        // One run drives Scheduled -> Executed.
+        task.run_and_notify().await;
+        assert_eq!(task.status, Status::Executed);
 
-        // Send Run command - this should not execute the task since next_exec is in the future
-        let (tx_run_no_exec, rx_run_no_exec) = oneshot::channel();
-        task.execute_command(TaskCmd::Run {
-            sender: tx_run_no_exec,
-        })
-        .await;
-        let no_exec_response = rx_run_no_exec.await.unwrap();
-        assert_eq!(no_exec_response.id, 1);
-        assert_eq!(
-            no_exec_response.status,
-            Status::Scheduled,
-            "Task should remain Scheduled when next_exec is in the future"
-        );
+        // With the single repeat spent, rescheduling retires the task.
+        task.reschedule_and_notify().await;
+        assert_eq!(task.status, Status::Finished);
+        assert!(task.is_terminal());
+    }
 
-        // Set next_exec to a past time to allow execution
-        let past_time = Utc::now() - Duration::seconds(10);
-        task.next_exec = Some(past_time);
+    /// The `run_task` loop initializes, publishes state to the shared cell, runs on a
+    /// `Run` command, and marks itself finished when its repeat cycle is exhausted.
+    #[tokio::test]
+    async fn test_run_task_loop_publishes_and_finishes() {
+        let (tx, rx) = mpsc::channel(1);
+        let mut task = Task::new("* * * * * * *", Some("Loop"), Some(1), Utc).unwrap();
+        task.set_id(3);
+        task.add_step_default(|| async { Ok(Success) });
+        task.set_receiver(rx);
 
-        // Send Run command - this should execute the task
-        let (tx_run, rx_run) = oneshot::channel();
-        task.execute_command(TaskCmd::Run { sender: tx_run }).await;
-        let run_response = rx_run.await.unwrap();
-        assert_eq!(run_response.id, 1);
-        assert_eq!(run_response.status, Status::Executed);
+        let shared = Arc::new(TaskShared::new());
+        let join = tokio::spawn(run_task(task, shared.clone()));
 
-        // Test Reschedule command
-        let (tx_reschedule, rx_reschedule) = oneshot::channel();
-        task.execute_command(TaskCmd::Reschedule {
-            sender: tx_reschedule,
-        })
-        .await;
-        let reschedule_response = rx_reschedule.await.unwrap();
-        assert_eq!(reschedule_response.id, 1);
-        assert_eq!(reschedule_response.status, Status::Finished);
+        // After self-initialization the task publishes Scheduled + a next execution.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        {
+            let state = shared.state.lock().unwrap();
+            assert_eq!(state.status, Status::Scheduled);
+            assert!(state.next_exec.is_some());
+        }
+
+        // Dispatch a single run; with repeat(1) the task then retires and the loop ends.
+        tx.send(TaskCmd::Run).await.unwrap();
+        join.await.unwrap();
+
+        assert!(shared.finished.load(Ordering::SeqCst));
+        assert_eq!(shared.state.lock().unwrap().status, Status::Finished);
     }
 
     #[tokio::test]
@@ -1284,7 +1327,6 @@ mod test {
     async fn test_lifecycle_callbacks_success_and_finish() {
         use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
-        use tokio::sync::oneshot;
 
         let success = Arc::new(AtomicUsize::new(0));
         let failure = Arc::new(AtomicUsize::new(0));
@@ -1317,19 +1359,11 @@ mod test {
 
         task.set_id(0);
         task.init();
-        // Force the task to be due.
-        task.next_exec = Some(Utc::now() - chrono::Duration::seconds(1));
 
-        // Run: fires on_success.
-        let (tx, rx) = oneshot::channel();
-        task.execute_command(TaskCmd::Run { sender: tx }).await;
-        let _ = rx.await.unwrap();
-
-        // Reschedule: repeats exhausted, so the task finishes and fires on_finish.
-        let (tx, rx) = oneshot::channel();
-        task.execute_command(TaskCmd::Reschedule { sender: tx })
-            .await;
-        let _ = rx.await.unwrap();
+        // A run fires on_success; the follow-up reschedule retires the task (repeat 1)
+        // and fires on_finish exactly once.
+        task.run_and_notify().await;
+        task.reschedule_and_notify().await;
 
         assert_eq!(success.load(Ordering::SeqCst), 1);
         assert_eq!(failure.load(Ordering::SeqCst), 0);
@@ -1341,7 +1375,6 @@ mod test {
     async fn test_lifecycle_callbacks_force_removed() {
         use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
-        use tokio::sync::oneshot;
 
         let failure = Arc::new(AtomicUsize::new(0));
         let finish = Arc::new(AtomicUsize::new(0));
@@ -1366,11 +1399,9 @@ mod test {
 
         task.set_id(0);
         task.init();
-        task.next_exec = Some(Utc::now() - chrono::Duration::seconds(1));
 
-        let (tx, rx) = oneshot::channel();
-        task.execute_command(TaskCmd::Run { sender: tx }).await;
-        let _ = rx.await.unwrap();
+        // ForceRemoved is terminal, so run_and_notify fires both on_failure and on_finish.
+        task.run_and_notify().await;
 
         assert_eq!(failure.load(Ordering::SeqCst), 1);
         assert_eq!(finish.load(Ordering::SeqCst), 1);


### PR DESCRIPTION
- Reworked the scheduler to be non-blocking: each task self-schedules and runs fire-and-forget, so a slow task no longer delays other tasks' schedules
- Added an overlap policy (OverlapPolicy::Skip default, or Queue) via TaskBuilder::overlap for when a run overruns its interval
- Added runtime status queries on SchedulerHandle: task_count(), statuses(), status_of(id), with TaskState reporting status, next_exec and running
- Added retry jitter (Jitter::None/Full/Equal) via RetryPolicy::with_jitter to spread retries and avoid a thundering herd
- Removed the internal request/response command layer (Init/Reschedule commands, TaskResponse, execute_tasks/init_tasks) in favour of shared per-task state
- Dropped the now-unused futures dependency; added the tiny fastrand dependency for jitter
- Added examples/overlap_and_status_example.rs and showcased jitter in retry_timeout_example.rs
- Updated README (overlap, observability, jitter) and crate docs
- Added and reworked unit tests for the new model (64 unit + 36 doctests pass)
- Bumped version to 0.3.2