### PR TITLE
release: v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tasklet"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Stavros Grigoriou <unix121@protonmail.com>"]
 edition = "2021"
 rust-version = "1.90.0"
@@ -21,10 +21,21 @@ tokio = { version = "1.48.0", features = ["rt", "sync", "time", "macros"] }
 thiserror = "2.0.17"
 # Small, dependency-free PRNG used only for retry backoff jitter.
 fastrand = "2.3"
+# Optional: enables `Serialize`/`Deserialize` on the observable state types
+# (`TaskState`, `Status`, `StepState`, `RunRecord`, ...) behind the `serde` feature.
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[features]
+default = []
+# Derive serde on the observable, read-only state types so a control plane / API can
+# emit them. Pulls in `serde` and chrono's serde integration for the timestamps.
+serde = ["dep:serde", "chrono/serde"]
 
 [dev-dependencies]
 simple_logger = "5.1.0"
 tokio-test = "0.4.4"
+# Used only by the `serde`-gated round-trip tests.
+serde_json = "1.0"
 # Examples and tests need the macros and a multi-thread runtime on top of the
 # library's minimal feature set.
 tokio = { version = "1.48.0", features = ["rt-multi-thread", "macros"] }

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ in order to run tasks asynchronously.
 | chrono    | 0.4.42  |
 | log       | 0.4.29  |
 | tokio     | 1.48.0  |
-| futures   | 0.3.31  |
 | thiserror | 2.0.17  |
+| fastrand  | 2.3     |
 
 ## How to use this library
 
@@ -34,7 +34,15 @@ In your `Cargo.toml` add:
 
 ```
 [dependencies]
-tasklet = "0.3.2"
+tasklet = "0.4.0"
+```
+
+To derive `serde` on the observable state types (`TaskState`, `Status`, `RunRecord`,
+`StepState`, ...) for a control plane or API, enable the optional `serde` feature:
+
+```
+[dependencies]
+tasklet = { version = "0.4.0", features = ["serde"] }
 ```
 
 > **Upgrading from 0.2.x?** See the [migration notes](#migrating-from-02x-to-030) below —
@@ -202,6 +210,72 @@ for state in handle.statuses() {
 ```
 
 See [`examples/overlap_and_status_example.rs`](/examples/overlap_and_status_example.rs) for a runnable demo.
+
+## Naming, runtime control and history
+
+Give a task a stable name and address it at runtime through the handle (added in 0.4.0).
+Names are unique within a scheduler; `add_task` rejects a duplicate with
+`TaskError::DuplicateTaskName`.
+
+```rust,no_run
+# use tasklet::{TaskBuilder, TaskScheduler};
+# use tasklet::task::TaskStepStatusOk::Success;
+# #[tokio::main]
+# async fn main() {
+let mut scheduler = TaskScheduler::default(chrono::Local);
+scheduler
+    .add_task(
+        TaskBuilder::new(chrono::Local)
+            .every("* * * * * * *")
+            .name("report")
+            .add_step("Step", || async { Ok(Success) })
+            .build(),
+    )
+    .unwrap();
+
+let handle = scheduler.handle();
+tokio::spawn(async move {
+    // Control a task by name (or by id) while the scheduler runs:
+    handle.pause_name("report");
+    handle.trigger_name("report"); // run once now, off-schedule
+    handle.resume_name("report");
+
+    // Observe what it did:
+    if let Some(id) = handle.id_of_name("report") {
+        let runs = handle.history(id);            // recent RunRecords
+        let steps = handle.step_states(id);       // per-step outcomes
+        println!("{} run(s), {} step(s)", runs.len(), steps.len());
+    }
+    handle.remove_name("report"); // reaped on the next round
+});
+
+scheduler.run().await;
+# }
+```
+
+Every `TaskState` from `handle.statuses()` now also carries the task's `name`, whether it
+is `paused`, its `run_count` and its `last_outcome`.
+
+## Sharing data between tasks
+
+A `Blackboard` is a cheaply-clonable, typed key/value store. Clone it into as many
+task/step closures as you like; they all read and write the same storage, replacing the
+ad-hoc `Arc<Mutex<HashMap<...>>>` boilerplate.
+
+```rust
+use tasklet::Blackboard;
+
+let board = Blackboard::new();
+board.set("attempts", 0u32);
+
+let shared = board.clone();
+shared.set("attempts", 3u32);
+
+assert_eq!(board.get::<u32>("attempts"), Some(3));
+```
+
+See [`examples/control_and_observability.rs`](/examples/control_and_observability.rs) for a
+runnable demo combining names, control, history and a shared blackboard.
 
 ## Migrating from 0.2.x to 0.3.0
 

--- a/examples/control_and_observability.rs
+++ b/examples/control_and_observability.rs
@@ -1,0 +1,111 @@
+use log::info;
+use simple_logger::SimpleLogger;
+use std::time::Duration;
+use tasklet::task::TaskStepStatusOk::Success;
+use tasklet::{Blackboard, TaskBuilder, TaskScheduler};
+
+/// Demonstrates the Layer 0 runtime-control and observability surface:
+///
+/// * **Named tasks**: tasks are addressed by a stable name through the handle.
+/// * **Blackboard**: a producer task writes a value that a consumer task reads,
+///   without any hand-rolled `Arc<Mutex<...>>`.
+/// * **Runtime control**: the handle pauses, triggers and inspects tasks while the
+///   scheduler runs.
+/// * **Run history / step states**: the handle reads what each task did.
+#[tokio::main]
+async fn main() {
+    SimpleLogger::new().init().unwrap();
+
+    // A blackboard shared between two tasks (each captures its own clone).
+    let board = Blackboard::new();
+
+    let mut scheduler = TaskScheduler::new(200, chrono::Local);
+
+    // Producer: bumps a counter on the blackboard every second.
+    let producer_board = board.clone();
+    let producer = TaskBuilder::new(chrono::Local)
+        .every("* * * * * * *")
+        .name("producer")
+        .add_step("increment", move || {
+            let board = producer_board.clone();
+            async move {
+                let n = board.get_or_insert("count", 0u32) + 1;
+                board.set("count", n);
+                info!("producer wrote count = {}", n);
+                Ok(Success)
+            }
+        })
+        .build();
+    scheduler.add_task(producer).unwrap();
+
+    // Consumer: reads whatever the producer last wrote.
+    let consumer_board = board.clone();
+    let consumer = TaskBuilder::new(chrono::Local)
+        .every("* * * * * * *")
+        .name("consumer")
+        .add_step("read", move || {
+            let board = consumer_board.clone();
+            async move {
+                match board.get::<u32>("count") {
+                    Some(n) => info!("consumer read count = {}", n),
+                    None => info!("consumer found no count yet"),
+                }
+                Ok(Success)
+            }
+        })
+        .build();
+    scheduler.add_task(consumer).unwrap();
+
+    // Drive control and observation from another task via the handle.
+    let handle = scheduler.handle();
+    let controller = tokio::spawn(async move {
+        // Let a few runs happen.
+        tokio::time::sleep(Duration::from_millis(2500)).await;
+
+        // Pause the consumer; the producer keeps going.
+        info!("[control] pausing consumer");
+        handle.pause_name("consumer");
+
+        tokio::time::sleep(Duration::from_millis(2000)).await;
+
+        // Trigger an immediate producer run, off-schedule.
+        info!("[control] triggering producer now");
+        handle.trigger_name("producer");
+
+        // Resume the consumer.
+        info!("[control] resuming consumer");
+        handle.resume_name("consumer");
+
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        // Inspect what happened.
+        for state in handle.statuses() {
+            info!(
+                "[status] task {} ({}) status={:?} runs={} last={:?} paused={}",
+                state.id,
+                state.name.as_deref().unwrap_or("-"),
+                state.status,
+                state.run_count,
+                state.last_outcome,
+                state.paused,
+            );
+        }
+        if let Some(id) = handle.id_of_name("producer") {
+            let history = handle.history(id);
+            info!("[history] producer has {} recorded run(s)", history.len());
+            for step in handle.step_states(id) {
+                info!(
+                    "[steps] producer step {} ({}) -> {:?}",
+                    step.index,
+                    step.description.as_deref().unwrap_or("-"),
+                    step.status
+                );
+            }
+        }
+    });
+
+    scheduler
+        .run_until(tokio::time::sleep(Duration::from_secs(8)))
+        .await;
+    controller.await.unwrap();
+}

--- a/src/blackboard.rs
+++ b/src/blackboard.rs
@@ -1,0 +1,192 @@
+//! A small, cheaply-clonable typed store for passing data between tasks and steps.
+//!
+//! Steps are `'static` closures, so anything they need from the outside has to be
+//! captured by value. A [`Blackboard`] is the shared thing you capture: clone it into
+//! as many task/step closures as you like and they all read and write the same
+//! underlying map. It replaces the ad-hoc `Arc<Mutex<HashMap<...>>>` boilerplate that
+//! would otherwise be repeated at every call site.
+//!
+//! Values are stored by string key and retrieved by type: [`Blackboard::get`] returns
+//! `Some` only if a value under that key was stored with the requested type.
+//!
+//! # Examples
+//!
+//! ```
+//! use tasklet::Blackboard;
+//!
+//! let board = Blackboard::new();
+//! board.set("attempts", 0u32);
+//!
+//! // A clone shares the same storage.
+//! let other = board.clone();
+//! other.set("attempts", 3u32);
+//!
+//! assert_eq!(board.get::<u32>("attempts"), Some(3));
+//! // Reading with the wrong type yields `None`.
+//! assert_eq!(board.get::<String>("attempts"), None);
+//! ```
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// A cheaply-clonable, thread-safe, typed key/value store shared between tasks and
+/// steps.
+///
+/// Cloning a `Blackboard` is cheap (it shares the same storage via an [`Arc`]); pass a
+/// clone into each closure that needs access.
+#[derive(Clone, Default)]
+pub struct Blackboard {
+    inner: Arc<Mutex<HashMap<String, Box<dyn Any + Send>>>>,
+}
+
+impl Blackboard {
+    /// Create a new, empty blackboard.
+    pub fn new() -> Self {
+        Blackboard {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Store `value` under `key`, replacing any previous value regardless of its type.
+    pub fn set<T>(&self, key: &str, value: T)
+    where
+        T: Send + 'static,
+    {
+        self.inner
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), Box::new(value));
+    }
+
+    /// Retrieve a clone of the value stored under `key`, if one exists and was stored
+    /// as type `T`. Returns `None` if the key is absent or holds a different type.
+    pub fn get<T>(&self, key: &str) -> Option<T>
+    where
+        T: Clone + Send + 'static,
+    {
+        self.inner
+            .lock()
+            .unwrap()
+            .get(key)
+            .and_then(|value| value.downcast_ref::<T>())
+            .cloned()
+    }
+
+    /// Return `true` if a value is stored under `key` (of any type).
+    pub fn contains(&self, key: &str) -> bool {
+        self.inner.lock().unwrap().contains_key(key)
+    }
+
+    /// Remove the value stored under `key`. Returns `true` if a value was present.
+    pub fn remove(&self, key: &str) -> bool {
+        self.inner.lock().unwrap().remove(key).is_some()
+    }
+
+    /// Retrieve the value under `key` if present and of type `T`, otherwise store and
+    /// return `default`.
+    pub fn get_or_insert<T>(&self, key: &str, default: T) -> T
+    where
+        T: Clone + Send + 'static,
+    {
+        let mut map = self.inner.lock().unwrap();
+        if let Some(existing) = map.get(key).and_then(|v| v.downcast_ref::<T>()) {
+            return existing.clone();
+        }
+        map.insert(key.to_string(), Box::new(default.clone()));
+        default
+    }
+
+    /// The number of stored keys.
+    pub fn len(&self) -> usize {
+        self.inner.lock().unwrap().len()
+    }
+
+    /// Whether the blackboard holds no values.
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().unwrap().is_empty()
+    }
+
+    /// A snapshot of all currently stored keys.
+    pub fn keys(&self) -> Vec<String> {
+        self.inner.lock().unwrap().keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn set_and_get_roundtrips() {
+        let board = Blackboard::new();
+        board.set("count", 42u32);
+        board.set("label", "hello".to_string());
+        assert_eq!(board.get::<u32>("count"), Some(42));
+        assert_eq!(board.get::<String>("label"), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn missing_key_is_none() {
+        let board = Blackboard::new();
+        assert_eq!(board.get::<u32>("nope"), None);
+        assert!(!board.contains("nope"));
+    }
+
+    #[test]
+    fn wrong_type_is_none() {
+        let board = Blackboard::new();
+        board.set("count", 42u32);
+        // Stored as u32; asking for a String must not succeed.
+        assert_eq!(board.get::<String>("count"), None);
+        // The value is still there under the correct type.
+        assert_eq!(board.get::<u32>("count"), Some(42));
+    }
+
+    #[test]
+    fn set_overwrites() {
+        let board = Blackboard::new();
+        board.set("count", 1u32);
+        board.set("count", 2u32);
+        assert_eq!(board.get::<u32>("count"), Some(2));
+    }
+
+    #[test]
+    fn clones_share_storage() {
+        let board = Blackboard::new();
+        let clone = board.clone();
+        board.set("shared", 7i64);
+        assert_eq!(clone.get::<i64>("shared"), Some(7));
+        clone.set("shared", 8i64);
+        assert_eq!(board.get::<i64>("shared"), Some(8));
+    }
+
+    #[test]
+    fn remove_reports_presence() {
+        let board = Blackboard::new();
+        board.set("k", 1u8);
+        assert!(board.remove("k"));
+        assert!(!board.remove("k"));
+        assert!(!board.contains("k"));
+    }
+
+    #[test]
+    fn get_or_insert_inserts_then_reads() {
+        let board = Blackboard::new();
+        assert_eq!(board.get_or_insert("k", 10u32), 10);
+        // Second call returns the stored value, ignoring the new default.
+        assert_eq!(board.get_or_insert("k", 99u32), 10);
+    }
+
+    #[test]
+    fn len_keys_and_empty() {
+        let board = Blackboard::new();
+        assert!(board.is_empty());
+        board.set("a", 1u32);
+        board.set("b", 2u32);
+        assert_eq!(board.len(), 2);
+        let mut keys = board.keys();
+        keys.sort();
+        assert_eq!(keys, vec!["a".to_string(), "b".to_string()]);
+    }
+}

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -2,6 +2,7 @@ use crate::errors::{TaskError, TaskResult};
 use crate::retry::RetryPolicy;
 use crate::task::{
     boxed_callback, CallbackFn, OverlapPolicy, Task, TaskStep, TaskStepStatusErr, TaskStepStatusOk,
+    DEFAULT_HISTORY_LIMIT,
 };
 use chrono::TimeZone;
 use cron::Schedule;
@@ -17,6 +18,10 @@ where
 {
     /// An optional task description.
     description: Option<String>,
+    /// An optional unique name used to address the task at runtime.
+    name: Option<String>,
+    /// The maximum number of run records to retain for the task.
+    history_limit: usize,
     /// The provided `TaskStep` vector.
     steps: Vec<TaskStep>,
     /// The provided `Schedule`, if not given,
@@ -62,6 +67,8 @@ where
         TaskBuilder {
             steps: Vec::new(),
             description: None,
+            name: None,
+            history_limit: DEFAULT_HISTORY_LIMIT,
             schedule: None,
             expression: "* * * * * * *".to_string(), // Default expression
             repeats: None,
@@ -87,6 +94,59 @@ where
     /// ```
     pub fn description(mut self, description: &str) -> TaskBuilder<T> {
         self.description = Some(description.to_string());
+        self
+    }
+
+    /// Set a unique name for the generated `Task`.
+    ///
+    /// A name is a stable, human-friendly identifier that can be used to address the
+    /// task at runtime through a [`SchedulerHandle`](crate::SchedulerHandle) (pause,
+    /// resume, trigger, remove, query). Names must be unique within a scheduler:
+    /// [`add_task`](crate::TaskScheduler::add_task) rejects a duplicate with
+    /// [`TaskError::DuplicateTaskName`](crate::TaskError::DuplicateTaskName).
+    ///
+    /// # Arguments
+    ///
+    /// * name  - A unique name for the task.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tasklet::TaskBuilder;
+    /// let _task = TaskBuilder::new(chrono::Local)
+    ///     .every("* * * * * * *")
+    ///     .name("nightly-report")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn name(mut self, name: &str) -> TaskBuilder<T> {
+        self.name = Some(name.to_string());
+        self
+    }
+
+    /// Set how many recent run records the generated `Task` retains.
+    ///
+    /// The scheduler keeps a bounded, per-task history of
+    /// [`RunRecord`](crate::task::RunRecord)s observable through a
+    /// [`SchedulerHandle`](crate::SchedulerHandle). The default is
+    /// 20; a value of `0` disables history (runs are still counted).
+    ///
+    /// # Arguments
+    ///
+    /// * limit - The maximum number of run records to keep.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tasklet::TaskBuilder;
+    /// let _task = TaskBuilder::new(chrono::Local)
+    ///     .every("* * * * * * *")
+    ///     .history_limit(100)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn history_limit(mut self, limit: usize) -> TaskBuilder<T> {
+        self.history_limit = limit;
         self
     }
 
@@ -366,6 +426,12 @@ where
         // Set the steps
         task.set_steps(self.steps);
 
+        // Transfer the identity / history configuration.
+        if let Some(name) = self.name.as_deref() {
+            task.set_name(name);
+        }
+        task.set_history_limit(self.history_limit);
+
         // Transfer the optional timeout / retry configuration.
         if let Some(timeout) = self.timeout {
             task.set_timeout(timeout);
@@ -509,5 +575,29 @@ mod test {
             Err(TaskError::InvalidCronExpression(_)) => {} // Expected
             _ => panic!("Expected InvalidCronExpression error"),
         }
+    }
+
+    /// `name` and `history_limit` are transferred onto the built task. (Layer 0)
+    #[test]
+    fn test_task_builder_name_and_history_limit() {
+        let task = TaskBuilder::new(chrono::Utc)
+            .every("* * * * * * *")
+            .name("my-task")
+            .history_limit(5)
+            .build()
+            .unwrap();
+        assert_eq!(task.name.as_deref(), Some("my-task"));
+        assert_eq!(task.history_limit, 5);
+    }
+
+    /// The default history limit is applied when not overridden. (Layer 0)
+    #[test]
+    fn test_task_builder_default_history_limit() {
+        let task = TaskBuilder::new(chrono::Utc)
+            .every("* * * * * * *")
+            .build()
+            .unwrap();
+        assert_eq!(task.history_limit, DEFAULT_HISTORY_LIMIT);
+        assert!(task.name.is_none());
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,10 @@ pub enum TaskError {
     #[error("Invalid cron expression: {0}")]
     InvalidCronExpression(String),
 
+    /// A task with the same name is already registered with the scheduler.
+    #[error("A task named '{0}' is already registered")]
+    DuplicateTaskName(String),
+
     /// A required component is missing.
     #[error("Missing required component: {0}")]
     MissingComponent(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,13 @@
 //!   happens when a run overruns its interval with an [`OverlapPolicy`] via
 //!   [`TaskBuilder::overlap`].
 //! * **Observability** — query the live task set at runtime through
-//!   [`SchedulerHandle::task_count`] / [`SchedulerHandle::statuses`].
+//!   [`SchedulerHandle::task_count`] / [`SchedulerHandle::statuses`], including per-task
+//!   run history ([`SchedulerHandle::history`]) and per-step state
+//!   ([`SchedulerHandle::step_states`]).
+//! * **Runtime control** — name a task with [`TaskBuilder::name`] and pause, resume,
+//!   trigger or remove it at runtime through a [`SchedulerHandle`], by id or by name.
+//! * **Shared data** — pass values between tasks and steps with a cheaply-clonable,
+//!   typed [`Blackboard`].
 //!
 //! # Example
 //!
@@ -41,6 +47,7 @@
 //! }
 //! ```
 
+mod blackboard;
 mod builders;
 pub mod errors;
 mod generator;
@@ -48,12 +55,13 @@ pub mod retry;
 mod scheduler;
 pub mod task;
 
+pub use blackboard::Blackboard;
 pub use builders::TaskBuilder;
 pub use errors::{TaskError, TaskResult};
 pub use generator::TaskGenerator;
 pub use retry::{Backoff, Jitter, RetryPolicy};
 pub use scheduler::{SchedulerHandle, TaskScheduler, TaskState};
-pub use task::{OverlapPolicy, Status, Task};
+pub use task::{OverlapPolicy, RunOutcome, RunRecord, Status, StepState, StepStatus, Task};
 
 /// Macro for consistent task-related logging
 ///

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,6 +1,8 @@
 use crate::errors::{TaskError, TaskResult};
 use crate::generator::TaskGenerator;
-use crate::task::{run_task, OverlapPolicy, Status, Task, TaskCmd, TaskShared};
+use crate::task::{
+    run_task, OverlapPolicy, RunOutcome, RunRecord, Status, StepState, Task, TaskCmd, TaskShared,
+};
 use crate::{scheduler_log, task_log};
 use chrono::prelude::*;
 use chrono::Utc;
@@ -19,26 +21,75 @@ use tokio::task::JoinHandle;
 #[derive(Debug)]
 pub struct TaskHandle {
     id: usize,
+    name: Option<String>,
     handle: JoinHandle<()>,
     sender: mpsc::Sender<TaskCmd>,
     shared: Arc<TaskShared>,
     overlap: OverlapPolicy,
 }
 
+/// A cheaply-clonable entry shared with [`SchedulerHandle`] so it can observe and
+/// control a task without touching the scheduler-private join handle. Rebuilt from the
+/// live task set at the end of every scheduler round.
+#[derive(Clone, Debug)]
+struct RegEntry {
+    id: usize,
+    name: Option<String>,
+    sender: mpsc::Sender<TaskCmd>,
+    shared: Arc<TaskShared>,
+}
+
+impl RegEntry {
+    /// Compute a point-in-time [`TaskState`] snapshot from the shared cell.
+    fn to_state(&self) -> TaskState {
+        let (status, next_exec) = {
+            let state = self.shared.state.lock().unwrap();
+            (state.status.clone(), state.next_exec)
+        };
+        let last_outcome = self
+            .shared
+            .history
+            .lock()
+            .unwrap()
+            .back()
+            .and_then(|r| r.outcome.clone());
+        TaskState {
+            id: self.id,
+            name: self.name.clone(),
+            status,
+            next_exec,
+            running: self.shared.running.load(Ordering::SeqCst),
+            paused: self.shared.paused.load(Ordering::SeqCst),
+            last_outcome,
+            run_count: self.shared.runs.load(Ordering::SeqCst),
+        }
+    }
+}
+
 /// A snapshot of a single task's state, as reported by [`SchedulerHandle`].
 ///
-/// This is a read-only view refreshed at the end of every scheduler round.
+/// This is a read-only view computed from the task's live shared state, refreshed at
+/// the end of every scheduler round.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub struct TaskState {
     /// The task's id, as assigned by the scheduler.
     pub id: usize,
+    /// The task's unique name, if one was set via [`TaskBuilder::name`](crate::TaskBuilder::name).
+    pub name: Option<String>,
     /// The task's lifecycle status as of the last completed round.
     pub status: Status,
     /// The task's next execution time, normalized to UTC (`None` if not scheduled).
     pub next_exec: Option<DateTime<Utc>>,
     /// Whether a run of this task is currently in progress.
     pub running: bool,
+    /// Whether the task is currently paused (its schedule is not dispatched).
+    pub paused: bool,
+    /// The outcome of the most recent completed run, if any.
+    pub last_outcome: Option<RunOutcome>,
+    /// The total number of runs started over the task's lifetime.
+    pub run_count: usize,
 }
 
 /// A cloneable handle used to control and observe a running [`TaskScheduler`].
@@ -68,7 +119,7 @@ pub struct TaskState {
 #[derive(Clone, Debug)]
 pub struct SchedulerHandle {
     notify: Arc<Notify>,
-    status: Arc<Mutex<Vec<TaskState>>>,
+    registry: Arc<Mutex<Vec<RegEntry>>>,
 }
 
 impl SchedulerHandle {
@@ -88,22 +139,151 @@ impl SchedulerHandle {
     ///
     /// The value reflects the most recently completed round.
     pub fn task_count(&self) -> usize {
-        self.status.lock().unwrap().len()
+        self.registry.lock().unwrap().len()
     }
 
     /// A snapshot of every live task's [`TaskState`], as of the last completed round.
     pub fn statuses(&self) -> Vec<TaskState> {
-        self.status.lock().unwrap().clone()
+        self.registry
+            .lock()
+            .unwrap()
+            .iter()
+            .map(RegEntry::to_state)
+            .collect()
+    }
+
+    /// The full [`TaskState`] of the task with the given id, if it is still registered.
+    pub fn state_of(&self, id: usize) -> Option<TaskState> {
+        self.registry
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|e| e.id == id)
+            .map(RegEntry::to_state)
     }
 
     /// The [`Status`] of the task with the given id, if it is still registered.
     pub fn status_of(&self, id: usize) -> Option<Status> {
-        self.status
+        self.state_of(id).map(|s| s.status)
+    }
+
+    /// The id of the task registered under the given name, if any.
+    pub fn id_of_name(&self, name: &str) -> Option<usize> {
+        self.registry
             .lock()
             .unwrap()
             .iter()
-            .find(|t| t.id == id)
-            .map(|t| t.status.clone())
+            .find(|e| e.name.as_deref() == Some(name))
+            .map(|e| e.id)
+    }
+
+    /// The [`Status`] of the task registered under the given name, if any.
+    pub fn status_of_name(&self, name: &str) -> Option<Status> {
+        self.id_of_name(name).and_then(|id| self.status_of(id))
+    }
+
+    /// The recent [`RunRecord`] history of the task with the given id, oldest first.
+    ///
+    /// Returns an empty vector if the task is unknown or has no retained history.
+    pub fn history(&self, id: usize) -> Vec<RunRecord> {
+        self.registry
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|e| e.id == id)
+            .map(|e| e.shared.history.lock().unwrap().iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// The per-step state of the last completed run of the task with the given id.
+    ///
+    /// Returns an empty vector if the task is unknown.
+    pub fn step_states(&self, id: usize) -> Vec<StepState> {
+        self.registry
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|e| e.id == id)
+            .map(|e| e.shared.steps.lock().unwrap().clone())
+            .unwrap_or_default()
+    }
+
+    /// Pause the task with the given id: its schedule stops being dispatched until
+    /// [`resume`](Self::resume) is called. A run already in progress is not interrupted.
+    ///
+    /// Returns `true` if the task was found.
+    pub fn pause(&self, id: usize) -> bool {
+        self.with_entry(id, |e| e.shared.paused.store(true, Ordering::SeqCst))
+    }
+
+    /// Resume a paused task so its schedule is dispatched again. Returns `true` if the
+    /// task was found.
+    pub fn resume(&self, id: usize) -> bool {
+        self.with_entry(id, |e| e.shared.paused.store(false, Ordering::SeqCst))
+    }
+
+    /// Trigger an immediate run of the task with the given id, regardless of its
+    /// schedule. If a run is already in progress, the trigger is queued to run once the
+    /// current run finishes (at most one queued). Returns `true` if the task was found.
+    pub fn trigger(&self, id: usize) -> bool {
+        self.with_entry(id, |e| {
+            if e.shared.running.load(Ordering::SeqCst) {
+                e.shared.pending.store(true, Ordering::SeqCst);
+            } else {
+                // Fire-and-forget; a full channel means a run is already queued.
+                let _ = e.sender.try_send(TaskCmd::Run);
+            }
+        })
+    }
+
+    /// Request removal of the task with the given id. The scheduler reaps it on its
+    /// next round. Returns `true` if the task was found.
+    pub fn remove(&self, id: usize) -> bool {
+        self.with_entry(id, |e| {
+            e.shared.remove_requested.store(true, Ordering::SeqCst)
+        })
+    }
+
+    /// Pause the task registered under the given name. Returns `true` if found.
+    pub fn pause_name(&self, name: &str) -> bool {
+        self.id_of_name(name)
+            .map(|id| self.pause(id))
+            .unwrap_or(false)
+    }
+
+    /// Resume the task registered under the given name. Returns `true` if found.
+    pub fn resume_name(&self, name: &str) -> bool {
+        self.id_of_name(name)
+            .map(|id| self.resume(id))
+            .unwrap_or(false)
+    }
+
+    /// Trigger the task registered under the given name. Returns `true` if found.
+    pub fn trigger_name(&self, name: &str) -> bool {
+        self.id_of_name(name)
+            .map(|id| self.trigger(id))
+            .unwrap_or(false)
+    }
+
+    /// Request removal of the task registered under the given name. Returns `true` if found.
+    pub fn remove_name(&self, name: &str) -> bool {
+        self.id_of_name(name)
+            .map(|id| self.remove(id))
+            .unwrap_or(false)
+    }
+
+    /// Run `f` against the entry with the given id, if present. Returns whether it was found.
+    fn with_entry<F>(&self, id: usize, f: F) -> bool
+    where
+        F: FnOnce(&RegEntry),
+    {
+        match self.registry.lock().unwrap().iter().find(|e| e.id == id) {
+            Some(entry) => {
+                f(entry);
+                true
+            }
+            None => false,
+        }
     }
 }
 
@@ -124,9 +304,9 @@ where
     timezone: T,
     /// Notified when a graceful shutdown is requested.
     shutdown: Arc<Notify>,
-    /// Snapshot of the live tasks' states, refreshed each round and read by
+    /// The observable/controllable registry, rebuilt each round and shared with every
     /// [`SchedulerHandle`].
-    status: Arc<Mutex<Vec<TaskState>>>,
+    registry: Arc<Mutex<Vec<RegEntry>>>,
 }
 
 /// `TaskScheduler` implementation.
@@ -156,7 +336,7 @@ where
             timezone,
             next_id: 0,
             shutdown: Arc::new(Notify::new()),
-            status: Arc::new(Mutex::new(Vec::new())),
+            registry: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -172,7 +352,7 @@ where
     pub fn handle(&self) -> SchedulerHandle {
         SchedulerHandle {
             notify: self.shutdown.clone(),
-            status: self.status.clone(),
+            registry: self.registry.clone(),
         }
     }
 
@@ -223,6 +403,10 @@ where
     ///
     /// * task - a `Task` instance.
     ///
+    /// If the task has a name (set via [`TaskBuilder::name`](crate::TaskBuilder::name)),
+    /// it must be unique within the scheduler; a duplicate is rejected with
+    /// [`TaskError::DuplicateTaskName`].
+    ///
     /// # Examples
     ///
     /// ```
@@ -240,6 +424,13 @@ where
     ) -> Result<&mut TaskScheduler<T>, TaskError> {
         match task {
             Ok(mut task) => {
+                // Enforce name uniqueness so a name is a stable, addressable identity.
+                if let Some(name) = task.name.as_deref() {
+                    if self.handles.iter().any(|h| h.name.as_deref() == Some(name)) {
+                        return Err(TaskError::DuplicateTaskName(name.to_string()));
+                    }
+                }
+
                 // A buffer of one is enough: the scheduler only dispatches a run when
                 // the task is idle, so at most one `Run` is ever in flight.
                 let (sender, receiver) = mpsc::channel(1);
@@ -247,12 +438,14 @@ where
                 task.set_receiver(receiver);
                 task.set_id(self.next_id);
                 let overlap = task.overlap;
-                let shared = Arc::new(TaskShared::new());
+                let name = task.name.clone();
+                let shared = Arc::new(TaskShared::new(task.history_limit));
                 let handle = tokio::spawn(run_task(task, shared.clone()));
 
                 // Push the handle
                 self.handles.push(TaskHandle {
                     id: self.next_id,
+                    name,
                     handle,
                     sender,
                     shared,
@@ -277,10 +470,17 @@ where
     fn dispatch_round(&mut self) {
         let now = Utc::now();
 
-        // Reap tasks that have reached a terminal state and published `finished`.
+        // Reap tasks that have reached a terminal state or been removed on request.
         self.handles.retain(|handle| {
-            if handle.shared.finished.load(Ordering::SeqCst) {
-                task_log!(handle.id, log::Level::Debug, "Removing finished task");
+            let finished = handle.shared.finished.load(Ordering::SeqCst);
+            let removed = handle.shared.remove_requested.load(Ordering::SeqCst);
+            if finished || removed {
+                let reason = if removed {
+                    "Removing task on request"
+                } else {
+                    "Removing finished task"
+                };
+                task_log!(handle.id, log::Level::Debug, "{}", reason);
                 handle.handle.abort();
                 false
             } else {
@@ -290,6 +490,11 @@ where
 
         // Dispatch due tasks.
         for handle in &self.handles {
+            // A paused task's schedule is not dispatched.
+            if handle.shared.paused.load(Ordering::SeqCst) {
+                continue;
+            }
+
             let due = match handle.shared.state.lock().unwrap().next_exec {
                 Some(next) => now >= next,
                 None => false,
@@ -314,25 +519,23 @@ where
             }
         }
 
-        self.refresh_status();
+        self.refresh_registry();
     }
 
-    /// Refresh the observable status snapshot from every live task's shared state.
-    fn refresh_status(&self) {
+    /// Rebuild the shared registry from the live task set so every [`SchedulerHandle`]
+    /// observes and controls the current tasks.
+    fn refresh_registry(&self) {
         let snapshot = self
             .handles
             .iter()
-            .map(|handle| {
-                let state = handle.shared.state.lock().unwrap();
-                TaskState {
-                    id: handle.id,
-                    status: state.status.clone(),
-                    next_exec: state.next_exec,
-                    running: handle.shared.running.load(Ordering::SeqCst),
-                }
+            .map(|handle| RegEntry {
+                id: handle.id,
+                name: handle.name.clone(),
+                sender: handle.sender.clone(),
+                shared: handle.shared.clone(),
             })
             .collect();
-        *self.status.lock().unwrap() = snapshot;
+        *self.registry.lock().unwrap() = snapshot;
     }
 
     /// Execute the `TaskGenerator` instance (if set).
@@ -366,6 +569,7 @@ where
             handle.handle.abort();
         }
         self.handles.clear();
+        self.registry.lock().unwrap().clear();
     }
 
     /// Run one iteration of the scheduler flow: run the generator (if due) and
@@ -468,6 +672,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::task::StepStatus;
     use crate::task::TaskStepStatusErr::ErrorDelete;
     use crate::task::TaskStepStatusOk::Success;
     use crate::TaskBuilder;
@@ -860,5 +1065,218 @@ mod test {
 
         assert_eq!(observed.load(Ordering::SeqCst), 0);
         assert_eq!(handle.status_of(0), None);
+    }
+
+    /// A duplicate task name is rejected. (Layer 0)
+    #[tokio::test]
+    async fn test_add_task_rejects_duplicate_name() {
+        let mut scheduler = TaskScheduler::new(1000, Local);
+        let t1 = TaskBuilder::new(Local)
+            .every("* * * * * * *")
+            .name("dup")
+            .build();
+        let t2 = TaskBuilder::new(Local)
+            .every("* * * * * * *")
+            .name("dup")
+            .build();
+        scheduler.add_task(t1).unwrap();
+        match scheduler.add_task(t2) {
+            Err(TaskError::DuplicateTaskName(name)) => assert_eq!(name, "dup"),
+            _ => panic!("expected DuplicateTaskName error"),
+        }
+        // A different name is accepted.
+        let t3 = TaskBuilder::new(Local)
+            .every("* * * * * * *")
+            .name("other")
+            .build();
+        assert!(scheduler.add_task(t3).is_ok());
+    }
+
+    /// Pausing a task stops its schedule from being dispatched; resuming restores it. (Layer 0)
+    #[tokio::test]
+    async fn test_control_pause_and_resume() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut scheduler = TaskScheduler::new(1000, Local);
+        scheduler.add_task(counting_task(&counter, None)).unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Populate the registry so the handle can address the task.
+        scheduler.dispatch_round();
+
+        let handle = scheduler.handle();
+        assert!(handle.pause(0));
+
+        // Force the task due and dispatch: a paused task must not run.
+        scheduler.handles[0].shared.state.lock().unwrap().next_exec =
+            Some(Utc::now() - chrono::Duration::seconds(1));
+        scheduler.dispatch_round();
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            0,
+            "paused task must not run"
+        );
+        assert!(handle.state_of(0).unwrap().paused);
+
+        // Resume and dispatch: the task runs.
+        assert!(handle.resume(0));
+        scheduler.handles[0].shared.state.lock().unwrap().next_exec =
+            Some(Utc::now() - chrono::Duration::seconds(1));
+        scheduler.dispatch_round();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(counter.load(Ordering::SeqCst), 1, "resumed task should run");
+    }
+
+    /// Triggering runs an idle task immediately, regardless of its schedule. (Layer 0)
+    #[tokio::test]
+    async fn test_control_trigger_runs_idle_task() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut scheduler = TaskScheduler::new(1000, Local);
+        scheduler.add_task(counting_task(&counter, None)).unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Populate the registry; the task is not due for ~1s.
+        scheduler.dispatch_round();
+
+        let handle = scheduler.handle();
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+        assert!(handle.trigger(0));
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "trigger should run the task now"
+        );
+        // Triggering an unknown id reports not-found.
+        assert!(!handle.trigger(99));
+    }
+
+    /// Requesting removal reaps the task on the next round. (Layer 0)
+    #[tokio::test]
+    async fn test_control_remove_reaps_task() {
+        let mut scheduler = TaskScheduler::new(1000, Local);
+        scheduler
+            .add_task(Task::new("* * * * * * *", None, None, Local))
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        scheduler.dispatch_round();
+
+        let handle = scheduler.handle();
+        assert_eq!(handle.task_count(), 1);
+        assert!(handle.remove(0));
+        // Next round reaps it.
+        scheduler.dispatch_round();
+        assert_eq!(scheduler.handles.len(), 0);
+        assert_eq!(handle.task_count(), 0);
+        assert!(!handle.remove(0));
+    }
+
+    /// The handle resolves names and exposes run history and step states. (Layer 0)
+    #[tokio::test]
+    async fn test_handle_name_history_and_steps() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut scheduler = TaskScheduler::new(100, Local);
+        let c = counter.clone();
+        let task = TaskBuilder::new(Local)
+            .every("* * * * * * *")
+            .name("worker")
+            .add_step("do work", move || {
+                let c = c.clone();
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    Ok(Success)
+                }
+            })
+            .build();
+        scheduler.add_task(task).unwrap();
+
+        let probe = scheduler.handle();
+        let observer = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(1600)).await;
+            let id = probe.id_of_name("worker");
+            let status = probe.status_of_name("worker");
+            let history = id.map(|i| probe.history(i)).unwrap_or_default();
+            let steps = id.map(|i| probe.step_states(i)).unwrap_or_default();
+            (id, status, history, steps)
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            scheduler.run_until(tokio::time::sleep(Duration::from_millis(2000))),
+        )
+        .await
+        .expect("scheduler did not stop");
+        let (id, status, history, steps) = observer.await.unwrap();
+
+        assert_eq!(id, Some(0));
+        assert!(status.is_some());
+        assert!(!history.is_empty(), "history should have records");
+        assert!(history
+            .iter()
+            .any(|r| r.outcome == Some(RunOutcome::Success)));
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].description.as_deref(), Some("do work"));
+        assert_eq!(steps[0].status, StepStatus::Succeeded);
+        assert!(counter.load(Ordering::SeqCst) >= 1);
+        // Unknown name resolves to nothing.
+        assert_eq!(scheduler.handle().id_of_name("nope"), None);
+    }
+
+    /// `TaskState` carries the new observable fields (name, run_count, last_outcome). (Layer 0)
+    #[tokio::test]
+    async fn test_task_state_exposes_new_fields() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut scheduler = TaskScheduler::new(100, Local);
+        let c = counter.clone();
+        let task = TaskBuilder::new(Local)
+            .every("* * * * * * *")
+            .name("named")
+            .add_step_default(move || {
+                let c = c.clone();
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    Ok(Success)
+                }
+            })
+            .build();
+        scheduler.add_task(task).unwrap();
+
+        let probe = scheduler.handle();
+        let observer = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(1600)).await;
+            probe.state_of(0)
+        });
+
+        scheduler
+            .run_until(tokio::time::sleep(Duration::from_millis(2000)))
+            .await;
+        let state = observer.await.unwrap().expect("state should exist");
+
+        assert_eq!(state.name.as_deref(), Some("named"));
+        assert!(state.run_count >= 1);
+        assert_eq!(state.last_outcome, Some(RunOutcome::Success));
+        assert!(!state.paused);
+    }
+
+    /// `TaskState` round-trips through serde. (Layer 0, `serde` feature)
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_roundtrip_task_state() {
+        let state = TaskState {
+            id: 1,
+            name: Some("t".to_string()),
+            status: Status::Scheduled,
+            next_exec: None,
+            running: false,
+            paused: true,
+            last_outcome: Some(RunOutcome::Success),
+            run_count: 5,
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let back: TaskState = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, 1);
+        assert_eq!(back.name.as_deref(), Some("t"));
+        assert_eq!(back.status, Status::Scheduled);
+        assert!(back.paused);
+        assert_eq!(back.last_outcome, Some(RunOutcome::Success));
+        assert_eq!(back.run_count, 5);
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -7,13 +7,17 @@ use crate::{step_log, task_log};
 use chrono::TimeZone;
 use chrono::{DateTime, Utc};
 use cron::Schedule;
+use std::collections::VecDeque;
 use std::fmt::{self, Debug};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc;
+
+/// The default number of past [`RunRecord`]s kept per task.
+pub(crate) const DEFAULT_HISTORY_LIMIT: usize = 20;
 
 /// Possible success status values for a step's execution.
 #[derive(Debug, Clone, PartialEq)]
@@ -133,6 +137,7 @@ impl TaskStep {
 
 /// Available task statuses.
 #[derive(Debug, PartialEq, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Status {
     #[default]
     /// The task is not initialized yet.
@@ -147,6 +152,68 @@ pub enum Status {
     Finished,
     /// The task is forcibly removed from the execution list due to fatal error.
     ForceRemoved,
+}
+
+/// The observable status of a single step within a task run.
+///
+/// Reflects the most recently completed run: before the first run every step is
+/// [`StepStatus::Pending`].
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum StepStatus {
+    /// The step has not run yet in the current cycle.
+    #[default]
+    Pending,
+    /// The step completed successfully.
+    Succeeded,
+    /// The step completed but reported non-fatal errors.
+    HadErrors,
+    /// The step failed (after exhausting any retries) or timed out.
+    Failed,
+    /// The step did not run because an earlier step failed.
+    Skipped,
+}
+
+/// A read-only view of a single step's identity and last-run outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct StepState {
+    /// The step's zero-based position within the task.
+    pub index: usize,
+    /// The step's optional description.
+    pub description: Option<String>,
+    /// The step's status as of the last completed run.
+    pub status: StepStatus,
+}
+
+/// The outcome of a single task run, recorded in the task's [`RunRecord`] history.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum RunOutcome {
+    /// Every step succeeded.
+    Success,
+    /// The run completed but at least one step reported non-fatal errors.
+    HadErrors,
+    /// A step failed after exhausting any retries.
+    Failed,
+    /// A step requested force-removal of the task.
+    ForceRemoved,
+}
+
+/// A record of one execution of a task, kept in a bounded per-task history.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RunRecord {
+    /// A per-task monotonically increasing run identifier.
+    pub run_id: usize,
+    /// When the run started (UTC).
+    pub started_at: DateTime<Utc>,
+    /// When the run finished (UTC); `None` while the run is still in progress.
+    pub finished_at: Option<DateTime<Utc>>,
+    /// The run's outcome; `None` while the run is still in progress.
+    pub outcome: Option<RunOutcome>,
+    /// The total number of step attempts made during the run (including retries).
+    pub attempts: usize,
 }
 
 /// What to do when a task's next scheduled time arrives while a previous run of
@@ -182,8 +249,22 @@ pub(crate) struct TaskShared {
     pub(crate) pending: AtomicBool,
     /// Set once the task reaches a terminal state so the scheduler reaps it.
     pub(crate) finished: AtomicBool,
+    /// Set while the task is paused; a paused task is not dispatched.
+    pub(crate) paused: AtomicBool,
+    /// Set when a caller has requested removal; the scheduler reaps the task next round.
+    pub(crate) remove_requested: AtomicBool,
+    /// Total number of runs started over the task's lifetime.
+    pub(crate) runs: AtomicUsize,
+    /// The next run id to hand out.
+    run_seq: AtomicUsize,
+    /// The maximum number of [`RunRecord`]s retained in `history`.
+    history_limit: usize,
     /// The observable lifecycle state (status + next execution time, in UTC).
     pub(crate) state: Mutex<SharedState>,
+    /// The per-step state as of the last completed run.
+    pub(crate) steps: Mutex<Vec<StepState>>,
+    /// A bounded history of recent runs, oldest first.
+    pub(crate) history: Mutex<VecDeque<RunRecord>>,
 }
 
 /// The observable, timezone-erased portion of a task's state.
@@ -197,15 +278,62 @@ pub(crate) struct SharedState {
 
 impl TaskShared {
     /// Create a fresh shared-state cell for an uninitialized task.
-    pub(crate) fn new() -> Self {
+    ///
+    /// `history_limit` bounds how many [`RunRecord`]s are retained.
+    pub(crate) fn new(history_limit: usize) -> Self {
         TaskShared {
             running: AtomicBool::new(false),
             pending: AtomicBool::new(false),
             finished: AtomicBool::new(false),
+            paused: AtomicBool::new(false),
+            remove_requested: AtomicBool::new(false),
+            runs: AtomicUsize::new(0),
+            run_seq: AtomicUsize::new(0),
+            history_limit,
             state: Mutex::new(SharedState {
                 status: Status::Init,
                 next_exec: None,
             }),
+            steps: Mutex::new(Vec::new()),
+            history: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// Record the start of a run and return its run id. Trims the history to the
+    /// configured limit.
+    fn start_run(&self, started_at: DateTime<Utc>) -> usize {
+        let run_id = self.run_seq.fetch_add(1, Ordering::SeqCst);
+        self.runs.fetch_add(1, Ordering::SeqCst);
+        let mut history = self.history.lock().unwrap();
+        while history.len() >= self.history_limit && !history.is_empty() {
+            history.pop_front();
+        }
+        // A `history_limit` of zero disables history entirely.
+        if self.history_limit > 0 {
+            history.push_back(RunRecord {
+                run_id,
+                started_at,
+                finished_at: None,
+                outcome: None,
+                attempts: 0,
+            });
+        }
+        run_id
+    }
+
+    /// Record the completion of the run with the given id.
+    fn finish_run(
+        &self,
+        run_id: usize,
+        finished_at: DateTime<Utc>,
+        outcome: RunOutcome,
+        attempts: usize,
+    ) {
+        let mut history = self.history.lock().unwrap();
+        if let Some(record) = history.iter_mut().rev().find(|r| r.run_id == run_id) {
+            record.finished_at = Some(finished_at);
+            record.outcome = Some(outcome);
+            record.attempts = attempts;
         }
     }
 }
@@ -223,10 +351,18 @@ where
     pub(crate) repeats: Option<usize>,
     /// (Optional) Task's description.
     pub(crate) description: String,
+    /// (Optional) caller-supplied unique name used to address the task at runtime.
+    pub(crate) name: Option<String>,
     /// The timezone of the task.
     pub(crate) timezone: T,
     /// (Internal) task id.
     pub(crate) task_id: usize,
+    /// (Internal) per-step state of the last run, republished after every run.
+    pub(crate) step_states: Vec<StepState>,
+    /// (Internal) total step attempts made during the last run.
+    pub(crate) last_attempts: usize,
+    /// The maximum number of run records retained for this task.
+    pub(crate) history_limit: usize,
     /// (Internal) next execution time.
     pub(crate) next_exec: Option<DateTime<T>>,
     /// (Internal) task status.
@@ -308,9 +444,13 @@ where
                 Some(s) => s.to_string(),
                 None => "-".to_string(),
             },
+            name: None,
             repeats,
             timezone,
             task_id: 0,
+            step_states: Vec::new(),
+            last_attempts: 0,
+            history_limit: DEFAULT_HISTORY_LIMIT,
             status: Status::default(),
             next_exec: None,
             receiver: None,
@@ -416,6 +556,33 @@ where
         self
     }
 
+    /// Set the task's unique name.
+    pub(crate) fn set_name(&mut self, name: &str) -> &mut Task<T> {
+        self.name = Some(name.to_string());
+        self
+    }
+
+    /// Set the maximum number of run records retained for this task.
+    pub(crate) fn set_history_limit(&mut self, limit: usize) -> &mut Task<T> {
+        self.history_limit = limit;
+        self
+    }
+
+    /// Rebuild the per-step snapshot from the current steps, marking every step
+    /// [`StepStatus::Pending`].
+    fn reset_step_states(&mut self) {
+        self.step_states = self
+            .steps
+            .iter()
+            .enumerate()
+            .map(|(index, step)| StepState {
+                index,
+                description: step.description.clone(),
+                status: StepStatus::Pending,
+            })
+            .collect();
+    }
+
     /// Set the callbacks invoked over the task's lifecycle.
     pub(crate) fn set_callbacks(
         &mut self,
@@ -443,6 +610,8 @@ where
     /// * id - The task's id.
     pub(crate) fn init(&mut self) {
         task_log!(self.task_id, log::Level::Debug, "Initializing");
+        // Seed the step snapshot so observers see the step list before the first run.
+        self.reset_step_states();
         match self.schedule.upcoming(self.timezone.clone()).next() {
             Some(next) => {
                 self.next_exec = Some(next);
@@ -494,6 +663,27 @@ where
         matches!(self.status, Status::Finished | Status::ForceRemoved)
     }
 
+    /// Classify the outcome of the run that just completed, based on the status and
+    /// the per-step snapshot. Call this after `run_and_notify` and before
+    /// `reschedule`, which would otherwise overwrite the status.
+    pub(crate) fn run_outcome(&self) -> RunOutcome {
+        match self.status {
+            Status::ForceRemoved => RunOutcome::ForceRemoved,
+            Status::Failed => RunOutcome::Failed,
+            _ => {
+                if self
+                    .step_states
+                    .iter()
+                    .any(|s| s.status == StepStatus::HadErrors)
+                {
+                    RunOutcome::HadErrors
+                } else {
+                    RunOutcome::Success
+                }
+            }
+        }
+    }
+
     /// The next execution time normalized to UTC, for the observable snapshot.
     pub(crate) fn next_exec_utc(&self) -> Option<DateTime<Utc>> {
         self.next_exec.as_ref().map(|d| d.with_timezone(&Utc))
@@ -520,6 +710,10 @@ where
                 let retry = self.retry_policy.clone();
                 let max_attempts = 1 + retry.as_ref().map(|r| r.max_retries).unwrap_or(0);
 
+                // Rebuild the per-step snapshot for this run and reset the attempt count.
+                self.reset_step_states();
+                self.last_attempts = 0;
+
                 let mut had_error: bool = false;
                 for (index, step) in self.steps.iter_mut().enumerate() {
                     if had_error {
@@ -531,6 +725,7 @@ where
                     let mut attempt: u32 = 0;
                     loop {
                         attempt += 1;
+                        self.last_attempts += 1;
 
                         // Run the step, optionally bounded by the configured timeout.
                         // A timeout is treated as a (retryable) `Error`.
@@ -557,20 +752,26 @@ where
                         match result {
                             Ok(status) => {
                                 match status {
-                                    TaskStepStatusOk::Success => step_log!(
-                                        self.task_id,
-                                        index,
-                                        log::Level::Debug,
-                                        "Executed successfully - {}",
-                                        step
-                                    ),
-                                    TaskStepStatusOk::HadErrors => step_log!(
-                                        self.task_id,
-                                        index,
-                                        log::Level::Debug,
-                                        "Executed with non-fatal errors - {}",
-                                        step
-                                    ),
+                                    TaskStepStatusOk::Success => {
+                                        step_log!(
+                                            self.task_id,
+                                            index,
+                                            log::Level::Debug,
+                                            "Executed successfully - {}",
+                                            step
+                                        );
+                                        self.step_states[index].status = StepStatus::Succeeded;
+                                    }
+                                    TaskStepStatusOk::HadErrors => {
+                                        step_log!(
+                                            self.task_id,
+                                            index,
+                                            log::Level::Debug,
+                                            "Executed with non-fatal errors - {}",
+                                            step
+                                        );
+                                        self.step_states[index].status = StepStatus::HadErrors;
+                                    }
                                 }
                                 self.status = Status::Executed;
                                 break;
@@ -583,6 +784,7 @@ where
                                     "Execution failed and task is marked for deletion - {}",
                                     step
                                 );
+                                self.step_states[index].status = StepStatus::Failed;
                                 self.status = Status::ForceRemoved;
                                 had_error = true;
                                 break;
@@ -614,11 +816,18 @@ where
                                     "Execution failed - {}",
                                     step
                                 );
+                                self.step_states[index].status = StepStatus::Failed;
                                 self.status = Status::Failed;
                                 had_error = true;
                                 break;
                             }
                         }
+                    }
+                }
+                // Any step still pending was never reached because an earlier step failed.
+                for step_state in self.step_states.iter_mut() {
+                    if step_state.status == StepStatus::Pending {
+                        step_state.status = StepStatus::Skipped;
                     }
                 }
                 // Avoid underflow in case of a task without steps.
@@ -693,9 +902,12 @@ fn publish<T>(task: &Task<T>, shared: &TaskShared)
 where
     T: TimeZone + Send + 'static,
 {
-    let mut state = shared.state.lock().unwrap();
-    state.status = task.status.clone();
-    state.next_exec = task.next_exec_utc();
+    {
+        let mut state = shared.state.lock().unwrap();
+        state.status = task.status.clone();
+        state.next_exec = task.next_exec_utc();
+    }
+    *shared.steps.lock().unwrap() = task.step_states.clone();
 }
 
 /// Execute the task once, fire its lifecycle callbacks, reschedule it and republish
@@ -706,10 +918,14 @@ where
     T: TimeZone + Send + 'static,
     <T as TimeZone>::Offset: Send,
 {
+    let run_id = shared.start_run(Utc::now());
     shared.running.store(true, Ordering::SeqCst);
     task.run_and_notify().await;
+    // Capture the outcome before `reschedule` overwrites the status.
+    let outcome = task.run_outcome();
     task.reschedule_and_notify().await;
     shared.running.store(false, Ordering::SeqCst);
+    shared.finish_run(run_id, Utc::now(), outcome, task.last_attempts);
     if task.is_terminal() {
         shared.finished.store(true, Ordering::SeqCst);
     }
@@ -1004,7 +1220,7 @@ mod test {
         task.add_step_default(|| async { Ok(Success) });
         task.set_receiver(rx);
 
-        let shared = Arc::new(TaskShared::new());
+        let shared = Arc::new(TaskShared::new(DEFAULT_HISTORY_LIMIT));
         let join = tokio::spawn(run_task(task, shared.clone()));
 
         // After self-initialization the task publishes Scheduled + a next execution.
@@ -1405,5 +1621,114 @@ mod test {
 
         assert_eq!(failure.load(Ordering::SeqCst), 1);
         assert_eq!(finish.load(Ordering::SeqCst), 1);
+    }
+
+    /// Step states track each step's outcome; a step after a failure is skipped. (Layer 0)
+    #[tokio::test]
+    async fn test_step_states_track_outcomes() {
+        let mut task = Task::new("* * * * * * *", Some("Steps"), Some(1), Utc).unwrap();
+        task.add_step("ok", || async { Ok(Success) });
+        task.add_step("boom", || async { Err(Error) });
+        task.add_step("never", || async { Ok(Success) });
+        task.set_id(0);
+        task.init();
+
+        // Before the first run every step is pending, with descriptions preserved.
+        assert_eq!(task.step_states.len(), 3);
+        assert!(task
+            .step_states
+            .iter()
+            .all(|s| s.status == StepStatus::Pending));
+        assert_eq!(task.step_states[0].description.as_deref(), Some("ok"));
+
+        assert!(task.run_task().await.is_ok());
+        assert_eq!(task.step_states[0].status, StepStatus::Succeeded);
+        assert_eq!(task.step_states[1].status, StepStatus::Failed);
+        assert_eq!(task.step_states[2].status, StepStatus::Skipped);
+        assert_eq!(task.last_attempts, 2);
+    }
+
+    /// A step returning `HadErrors` classifies the run outcome as `HadErrors`. (Layer 0)
+    #[tokio::test]
+    async fn test_run_outcome_had_errors() {
+        let mut task = Task::new("* * * * * * *", None, Some(1), Utc).unwrap();
+        task.add_step_default(|| async { Ok(TaskStepStatusOk::HadErrors) });
+        task.init();
+        assert!(task.run_task().await.is_ok());
+        assert_eq!(task.step_states[0].status, StepStatus::HadErrors);
+        assert_eq!(task.run_outcome(), RunOutcome::HadErrors);
+    }
+
+    /// Run history records each run's outcome and is bounded by the history limit. (Layer 0)
+    #[tokio::test]
+    async fn test_run_history_records_and_caps() {
+        let mut task = Task::new("* * * * * * *", Some("Hist"), None, Utc).unwrap();
+        task.set_id(0);
+        task.set_history_limit(2);
+        task.add_step_default(|| async { Ok(Success) });
+        task.init();
+
+        let shared = TaskShared::new(task.history_limit);
+        for _ in 0..3 {
+            run_once(&mut task, &shared).await;
+        }
+
+        let hist = shared.history.lock().unwrap().clone();
+        // Only the two most recent runs are retained, oldest first.
+        assert_eq!(hist.len(), 2);
+        assert_eq!(hist.front().unwrap().run_id, 1);
+        assert_eq!(hist.back().unwrap().run_id, 2);
+        assert!(hist
+            .iter()
+            .all(|r| r.outcome == Some(RunOutcome::Success) && r.finished_at.is_some()));
+        // The lifetime counter is not bounded by the retained history.
+        assert_eq!(shared.runs.load(Ordering::SeqCst), 3);
+        // The per-step snapshot is published to the shared cell.
+        assert_eq!(
+            shared.steps.lock().unwrap()[0].status,
+            StepStatus::Succeeded
+        );
+    }
+
+    /// A `history_limit` of zero disables run history but still counts runs. (Layer 0)
+    #[tokio::test]
+    async fn test_history_limit_zero_disables_history() {
+        let mut task = Task::new("* * * * * * *", None, None, Utc).unwrap();
+        task.set_history_limit(0);
+        task.add_step_default(|| async { Ok(Success) });
+        task.init();
+
+        let shared = TaskShared::new(task.history_limit);
+        run_once(&mut task, &shared).await;
+
+        assert!(shared.history.lock().unwrap().is_empty());
+        assert_eq!(shared.runs.load(Ordering::SeqCst), 1);
+    }
+
+    /// The observable state types round-trip through serde. (Layer 0, `serde` feature)
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_roundtrip_observability_types() {
+        let step = StepState {
+            index: 0,
+            description: Some("s".to_string()),
+            status: StepStatus::Succeeded,
+        };
+        let json = serde_json::to_string(&step).unwrap();
+        assert_eq!(serde_json::from_str::<StepState>(&json).unwrap(), step);
+
+        let status = Status::Scheduled;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(serde_json::from_str::<Status>(&json).unwrap(), status);
+
+        let record = RunRecord {
+            run_id: 3,
+            started_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            finished_at: Some(Utc.timestamp_opt(1_700_000_001, 0).unwrap()),
+            outcome: Some(RunOutcome::HadErrors),
+            attempts: 2,
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        assert_eq!(serde_json::from_str::<RunRecord>(&json).unwrap(), record);
     }
 }


### PR DESCRIPTION
- Added stable task names via TaskBuilder::name; names are unique per scheduler and add_task rejects duplicates with TaskError::DuplicateTaskName
- Added runtime control on SchedulerHandle: pause/resume/trigger/remove, each by id or by name (pause_name, trigger_name, ...)
- Added per-task run history (RunRecord: run_id, started/finished, outcome, attempts), bounded by TaskBuilder::history_limit and read via SchedulerHandle::history(id)
- Added per-step observability (StepState/StepStatus) for the last completed run, read via SchedulerHandle::step_states(id)
- Enriched TaskState with name, paused, run_count and last_outcome, plus SchedulerHandle::state_of/id_of_name/status_of_name
- Added an optional `serde` feature that derives Serialize/Deserialize on the observable state types (TaskState, Status, RunRecord, StepState, RunOutcome)
- Added Blackboard: a cheaply-clonable, typed key/value store for passing data between tasks and steps, replacing ad-hoc Arc<Mutex<HashMap>>
- Reworked the scheduler's observability into a shared registry rebuilt each round so a SchedulerHandle can both observe and control the live task set
- Added examples/control_and_observability.rs (names, control, history, blackboard); updated README with naming/control/history and blackboard sections
- Added unit and serde-gated tests (84 unit + 39 doctests by default; 86 unit + 39 doctests with --features serde); clippy, fmt and cargo doc clean
- Bumped version to 0.4.0