### PR TITLE
release: v0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tasklet"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Stavros Grigoriou <unix121@protonmail.com>"]
 edition = "2021"
 rust-version = "1.90.0"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In your `Cargo.toml` add:
 
 ```
 [dependencies]
-tasklet = "0.4.1"
+tasklet = "0.5.0"
 ```
 
 To derive `serde` on the observable state types (`TaskState`, `Status`, `RunRecord`,
@@ -42,7 +42,7 @@ To derive `serde` on the observable state types (`TaskState`, `Status`, `RunReco
 
 ```
 [dependencies]
-tasklet = { version = "0.4.1", features = ["serde"] }
+tasklet = { version = "0.5.0", features = ["serde"] }
 ```
 
 > **Upgrading from 0.2.x?** See the [migration notes](#migrating-from-02x-to-030) below —
@@ -53,7 +53,9 @@ tasklet = { version = "0.4.1", features = ["serde"] }
 Find more examples in the [examples](/examples) folder.
 
 Task steps are **asynchronous**: every step is a closure that returns a future, so it can
-`.await` real work (I/O, timers, network calls) without blocking the runtime.
+`.await` real work (I/O, timers, network calls) without blocking the runtime. Each step is
+handed a `TaskContext` (write `|_ctx|` to ignore it) that identifies the run and gives
+access to shared and per-run data - see [Step context and data flow](#step-context-and-data-flow).
 
 ```rust
 use log::info;
@@ -82,11 +84,11 @@ async fn main() {
         TaskBuilder::new(chrono::Local)
             .every("1 * * * * * *")
             .description("A simple task")
-            .add_step("Step 1", || async {
+            .add_step("Step 1", |_ctx| async {
                 info!("Hello from step 1");
                 Ok(Success) // Let the scheduler know this step was a success.
             })
-            .add_step("Step 2", move || {
+            .add_step("Step 2", move |_ctx| {
                 // Snapshot per-run state, then move it into the async block so the
                 // returned future is `'static`.
                 let count = exec_count;
@@ -107,6 +109,43 @@ async fn main() {
     scheduler.run().await;
 }
 ```
+
+## Step context and data flow
+
+Every step receives a `TaskContext` for the current attempt. It identifies the run
+(`task_id`, `task_name`, `run_id`, `step_index`, `attempt`) and exposes two typed
+key/value stores:
+
+- **`ctx.blackboard()`** - the task-level [`Blackboard`], shared across every run of the
+  task. Attach one with `.blackboard(...)` on the builder, or share the same blackboard
+  across several tasks to pass data between them.
+- **`ctx.run_store()`** - a fresh store created for each run, so a step can hand values to
+  later steps in the same run without leaking into the next run (an XCom-like scratchpad).
+
+```rust
+use tasklet::task::TaskStepStatusOk::Success;
+use tasklet::{Blackboard, TaskBuilder};
+
+let board = Blackboard::new();
+let _task = TaskBuilder::new(chrono::Local)
+    .every("* * * * * * *")
+    .blackboard(board.clone())
+    .add_step("produce", |ctx| async move {
+        ctx.run_store().set("value", (ctx.run_id() as u32 + 1) * 10);
+        Ok(Success)
+    })
+    .add_step("consume", |ctx| async move {
+        let value = ctx.run_store().get::<u32>("value").unwrap_or(0);
+        // Task-level state survives across runs.
+        let total = ctx.blackboard().get_or_insert("runs", 0u32) + 1;
+        ctx.blackboard().set("runs", total);
+        println!("run {} produced/consumed {} (total runs: {})", ctx.run_id(), value, total);
+        Ok(Success)
+    })
+    .build();
+```
+
+See [`examples/context_and_spawner.rs`](/examples/context_and_spawner.rs) for a runnable demo.
 
 ## Graceful shutdown
 
@@ -155,7 +194,7 @@ let _task = TaskBuilder::new(chrono::Local)
     .on_success(|| async { println!("run succeeded"); })
     .on_failure(|| async { eprintln!("run failed"); })
     .on_finish(|| async { println!("task finished its lifecycle"); })
-    .add_step("Step", || async { Ok(Success) })
+    .add_step("Step", |_ctx| async { Ok(Success) })
     .build();
 ```
 
@@ -185,7 +224,7 @@ run is still in progress, the `OverlapPolicy` decides what happens (added in 0.3
 let _task = TaskBuilder::new(chrono::Local)
     .every("* * * * * * *")
     .overlap(OverlapPolicy::Queue)
-    .add_step("Step", || async { Ok(Success) })
+    .add_step("Step", |_ctx| async { Ok(Success) })
     .build();
 ```
 
@@ -265,7 +304,7 @@ scheduler
         TaskBuilder::new(chrono::Local)
             .every("* * * * * * *")
             .name("report")
-            .add_step("Step", || async { Ok(Success) })
+            .add_step("Step", |_ctx| async { Ok(Success) })
             .build(),
     )
     .unwrap();
@@ -291,7 +330,39 @@ scheduler.run().await;
 ```
 
 Every `TaskState` from `handle.statuses()` now also carries the task's `name`, whether it
-is `paused`, its `run_count` and its `last_outcome`.
+is `paused`, its `run_count` and its `last_outcome`. The registry is populated when a task
+is added, so the handle can observe and control tasks before `run()` is even called.
+
+## Adding tasks at runtime
+
+The `SchedulerHandle` is type-erased and cannot carry a `Task<T>`. To add tasks to a
+*running* scheduler, grab a `TaskSpawner` with `scheduler.spawner()` before running. It is
+cloneable and `Send`, so you can hand fully-built tasks to the scheduler from anywhere
+(added in 0.5.0):
+
+```rust,no_run
+# use tasklet::{TaskBuilder, TaskScheduler};
+# use tasklet::task::TaskStepStatusOk::Success;
+# #[tokio::main]
+# async fn main() {
+let mut scheduler = TaskScheduler::default(chrono::Local);
+let spawner = scheduler.spawner();
+
+tokio::spawn(async move {
+    let task = TaskBuilder::new(chrono::Local)
+        .every("* * * * * * *")
+        .add_step("Step", |_ctx| async { Ok(Success) })
+        .build();
+    // Fire-and-forget, or use `spawn_get_id(...).await` to get the assigned id.
+    let _ = spawner.spawn(task);
+});
+
+scheduler.run().await;
+# }
+```
+
+Spawned tasks are picked up on the scheduler's next round, so they are processed only while
+the scheduler is running (like tasks produced by a `TaskGenerator`).
 
 ## Sharing data between tasks
 
@@ -314,6 +385,26 @@ assert_eq!(board.get::<u32>("attempts"), Some(3));
 See [`examples/control_and_observability.rs`](/examples/control_and_observability.rs) for a
 runnable demo combining names, control, history and a shared blackboard.
 
+## Migrating from 0.4.x to 0.5.0
+
+- **Steps now receive a `TaskContext`.** The step closure signature changed from
+  `FnMut() -> Future` to `FnMut(TaskContext) -> Future`. Add a parameter to every step; if
+  you do not need it, ignore it with `|_ctx|`:
+
+  ```rust,ignore
+  // 0.4.x
+  .add_step("Step", || async { Ok(Success) })
+  // 0.5.0
+  .add_step("Step", |_ctx| async { Ok(Success) })
+  ```
+
+  Lifecycle callbacks (`on_success` / `on_failure` / `on_finish`) are unchanged - they
+  still take `|| async { ... }`. The context gives steps access to a shared `Blackboard`
+  and a per-run store; see [Step context and data flow](#step-context-and-data-flow).
+- **New, additive:** `TaskBuilder::blackboard(...)` attaches a shared blackboard;
+  `TaskScheduler::spawner()` returns a `TaskSpawner` for adding tasks to a running
+  scheduler; the observable registry is now populated at `add_task` time.
+
 ## Migrating from 0.2.x to 0.3.0
 
 - **Steps are now async.** A step closure must return a future. Wrap synchronous bodies
@@ -323,7 +414,7 @@ runnable demo combining names, control, history and a shared blackboard.
   // 0.2.x
   .add_step("Step", || Ok(Success))
   // 0.3.0
-  .add_step("Step", || async { Ok(Success) })
+  .add_step("Step", |_ctx| async { Ok(Success) })
   ```
 
   For state that changes between runs, snapshot it in the (`FnMut`) closure and `move` the

--- a/examples/context_and_spawner.rs
+++ b/examples/context_and_spawner.rs
@@ -1,0 +1,89 @@
+use log::info;
+use simple_logger::SimpleLogger;
+use std::time::Duration;
+use tasklet::task::TaskStepStatusOk::Success;
+use tasklet::{Blackboard, TaskBuilder, TaskScheduler};
+
+/// Demonstrates the two 0.5.0 kernel additions:
+///
+/// * **`TaskContext`**: each step is handed a context carrying the run's identity
+///   (task id/name, run id, step index, attempt), a task-level [`Blackboard`] shared
+///   across runs, and a per-run store for handing values between steps within one run
+///   (XCom-like), without capturing any `Arc<Mutex<...>>` by hand.
+/// * **`TaskSpawner`**: add a fully-built task to the scheduler while it is already
+///   running.
+#[tokio::main]
+async fn main() {
+    SimpleLogger::new().init().unwrap();
+
+    // A task-level blackboard, attached through the builder so every step gets it from
+    // its context (no manual clone-capture needed).
+    let board = Blackboard::new();
+
+    let mut scheduler = TaskScheduler::new(200, chrono::Local);
+
+    // A two-step task. The first step produces a value into the per-run store; the
+    // second step consumes it. The task-level blackboard counts total runs.
+    let pipeline = TaskBuilder::new(chrono::Local)
+        .every("* * * * * * *")
+        .name("pipeline")
+        .blackboard(board.clone())
+        .add_step("produce", |ctx| async move {
+            // Per-run scratch space: fresh each run, visible to later steps this run.
+            let value = (ctx.run_id() as u32 + 1) * 10;
+            ctx.run_store().set("value", value);
+            info!(
+                "[{} run {}] produced value = {}",
+                ctx.task_name().unwrap_or("-"),
+                ctx.run_id(),
+                value
+            );
+            Ok(Success)
+        })
+        .add_step("consume", |ctx| async move {
+            let value = ctx.run_store().get::<u32>("value").unwrap_or(0);
+            // Task-level state: survives across runs.
+            let total = ctx.blackboard().get_or_insert("runs", 0u32) + 1;
+            ctx.blackboard().set("runs", total);
+            info!(
+                "[{} run {}] consumed value = {} (total runs so far: {})",
+                ctx.task_name().unwrap_or("-"),
+                ctx.run_id(),
+                value,
+                total
+            );
+            Ok(Success)
+        })
+        .build();
+    scheduler.add_task(pipeline).unwrap();
+
+    // Add a second task at runtime, from outside the scheduler, using a spawner.
+    let spawner = scheduler.spawner();
+    let injector = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(2500)).await;
+        info!("[spawn] injecting a 'late' task into the running scheduler");
+        let late = TaskBuilder::new(chrono::Local)
+            .every("* * * * * * *")
+            .name("late")
+            .add_step("tick", |ctx| async move {
+                info!("late task tick (attempt {})", ctx.attempt());
+                Ok(Success)
+            })
+            .build();
+        // Await the id the scheduler assigns it.
+        match spawner.spawn_get_id(late).await {
+            Ok(id) => info!("[spawn] 'late' task registered with id {}", id),
+            Err(e) => info!("[spawn] failed to register: {}", e),
+        }
+    });
+
+    scheduler
+        .run_until(tokio::time::sleep(Duration::from_secs(5)))
+        .await;
+    injector.await.unwrap();
+
+    info!(
+        "final total pipeline runs recorded on the blackboard: {:?}",
+        board.get::<u32>("runs")
+    );
+}

--- a/examples/control_and_observability.rs
+++ b/examples/control_and_observability.rs
@@ -26,7 +26,7 @@ async fn main() {
     let producer = TaskBuilder::new(chrono::Local)
         .every("* * * * * * *")
         .name("producer")
-        .add_step("increment", move || {
+        .add_step("increment", move |_ctx| {
             let board = producer_board.clone();
             async move {
                 let n = board.get_or_insert("count", 0u32) + 1;
@@ -43,7 +43,7 @@ async fn main() {
     let consumer = TaskBuilder::new(chrono::Local)
         .every("* * * * * * *")
         .name("consumer")
-        .add_step("read", move || {
+        .add_step("read", move |_ctx| {
             let board = consumer_board.clone();
             async move {
                 match board.get::<u32>("count") {

--- a/examples/force_remove_example.rs
+++ b/examples/force_remove_example.rs
@@ -24,11 +24,11 @@ async fn main() {
         TaskBuilder::new(chrono::Local)
             .every("0,5,10,15,20,25,30,35,40,45,50,55 * * * * * *")
             .description("A simple task")
-            .add_step("Step 1", || async {
+            .add_step("Step 1", |_ctx| async {
                 info!("Hello from step 1");
                 Ok(Success) // Let the scheduler know this step was a success.
             })
-            .add_step("Step 2", move || {
+            .add_step("Step 2", move |_ctx| {
                 // Snapshot the counter for this run, then advance it so the returned
                 // future can own its state and stay `'static`.
                 let count = exec_count;

--- a/examples/generator_example.rs
+++ b/examples/generator_example.rs
@@ -26,11 +26,11 @@ async fn main() {
                     .every("0,10,20,30,40,50 * * * * * *")
                     .description("Generated task")
                     .repeat(2)
-                    .add_step_default(|| async {
+                    .add_step_default(|_ctx| async {
                         info!("[Step 1] This is a generated task!");
                         Ok(Success)
                     })
-                    .add_step_default(|| async {
+                    .add_step_default(|_ctx| async {
                         info!("[Step 2] This is generated task!");
                         Ok(Success)
                     })

--- a/examples/one_task_example.rs
+++ b/examples/one_task_example.rs
@@ -24,11 +24,11 @@ async fn main() {
         TaskBuilder::new(chrono::Local)
             .every("1 * * * * * *")
             .description("A simple task")
-            .add_step_default(|| async {
+            .add_step_default(|_ctx| async {
                 info!("Hello from step 1");
                 Ok(Success) // Let the scheduler know this step was a success.
             })
-            .add_step_default(move || {
+            .add_step_default(move |_ctx| {
                 // Snapshot the counter for this run, then advance it so the returned
                 // future can own its state and stay `'static`.
                 let count = exec_count;

--- a/examples/overlap_and_status_example.rs
+++ b/examples/overlap_and_status_example.rs
@@ -28,7 +28,7 @@ async fn main() {
         .every("* * * * * * *")
         .description("Slow task")
         .overlap(OverlapPolicy::Skip) // default; shown here for clarity
-        .add_step("Slow step", move || {
+        .add_step("Slow step", move |_ctx| {
             let s = s.clone();
             async move {
                 let n = s.fetch_add(1, Ordering::SeqCst) + 1;
@@ -46,7 +46,7 @@ async fn main() {
     let fast_task = TaskBuilder::new(chrono::Local)
         .every("* * * * * * *")
         .description("Fast task")
-        .add_step("Fast step", move || {
+        .add_step("Fast step", move |_ctx| {
             let f = f.clone();
             async move {
                 info!("fast run #{}", f.fetch_add(1, Ordering::SeqCst) + 1);

--- a/examples/read_me_example.rs
+++ b/examples/read_me_example.rs
@@ -24,11 +24,11 @@ async fn main() {
         TaskBuilder::new(chrono::Local)
             .every("1 * * * * * *")
             .description("A simple task")
-            .add_step("Step 1", || async {
+            .add_step("Step 1", |_ctx| async {
                 info!("Hello from step 1");
                 Ok(Success) // Let the scheduler know this step was a success.
             })
-            .add_step("Step 2", move || {
+            .add_step("Step 2", move |_ctx| {
                 // Snapshot the counter for this run, then advance it. The async block
                 // owns the snapshot so the returned future stays `'static`.
                 let count = exec_count;

--- a/examples/retry_timeout_example.rs
+++ b/examples/retry_timeout_example.rs
@@ -46,7 +46,7 @@ async fn main() {
             .on_success(|| async { info!("run succeeded") })
             .on_failure(|| async { info!("run failed after exhausting retries") })
             .on_finish(|| async { info!("task finished its lifecycle") })
-            .add_step("Flaky step", move || {
+            .add_step("Flaky step", move |_ctx| {
                 let attempts = step_attempts.clone();
                 async move {
                     let attempt = attempts.fetch_add(1, Ordering::SeqCst);

--- a/examples/schedule_helpers_and_streaming.rs
+++ b/examples/schedule_helpers_and_streaming.rs
@@ -20,11 +20,11 @@ async fn main() {
     // second step is slow, so its predecessor shows as completed while it runs.
     let task = TaskBuilder::new(chrono::Local)
         .every_seconds(2)
-        .add_step("prepare", || async {
+        .add_step("prepare", |_ctx| async {
             info!("step 1: prepare");
             Ok(Success)
         })
-        .add_step("work (slow)", || async {
+        .add_step("work (slow)", |_ctx| async {
             info!("step 2: working...");
             tokio::time::sleep(Duration::from_millis(1200)).await;
             info!("step 2: done");

--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -25,7 +25,7 @@ async fn main() {
                 .every("1, 10, 20 * * * * * *")
                 .description("Just some task")
                 .repeat(5)
-                .add_step_default(move || {
+                .add_step_default(move |_ctx| {
                     count -= 1;
                     let remaining = count;
                     async move {
@@ -40,7 +40,7 @@ async fn main() {
             TaskBuilder::new(chrono::Utc)
                 .every("1, 10 , 20 * * * * * *")
                 .description("Just another task")
-                .add_step_default(|| async {
+                .add_step_default(|_ctx| async {
                     info!("I will run forever!");
                     Ok(Success)
                 })

--- a/examples/task_builder_example.rs
+++ b/examples/task_builder_example.rs
@@ -19,8 +19,8 @@ async fn main() {
             .every("* * * * * *")
             .description("Some description")
             .repeat(5)
-            .add_step("First step", || async { Ok(Success) })
-            .add_step("Second step", || async { Ok(Success) })
+            .add_step("First step", |_ctx| async { Ok(Success) })
+            .add_step("Second step", |_ctx| async { Ok(Success) })
             .build(),
     );
 

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -1,8 +1,9 @@
+use crate::blackboard::Blackboard;
 use crate::errors::{TaskError, TaskResult};
 use crate::retry::RetryPolicy;
 use crate::task::{
-    boxed_callback, CallbackFn, OverlapPolicy, Task, TaskStep, TaskStepStatusErr, TaskStepStatusOk,
-    DEFAULT_HISTORY_LIMIT,
+    boxed_callback, CallbackFn, OverlapPolicy, Task, TaskContext, TaskStep, TaskStepStatusErr,
+    TaskStepStatusOk, DEFAULT_HISTORY_LIMIT,
 };
 use chrono::TimeZone;
 use cron::Schedule;
@@ -43,6 +44,8 @@ where
     on_finish: Option<Box<CallbackFn>>,
     /// Behaviour when a run overlaps a still-running one.
     overlap: OverlapPolicy,
+    /// (Optional) task-level blackboard shared with every step through its context.
+    blackboard: Option<Blackboard>,
     /// The Task/Scheduler timezone.
     timezone: T,
 }
@@ -78,6 +81,7 @@ where
             on_failure: None,
             on_finish: None,
             overlap: OverlapPolicy::default(),
+            blackboard: None,
             timezone,
         }
     }
@@ -342,6 +346,35 @@ where
     ///     .build()
     ///     .unwrap();
     /// ```
+    /// Attach a task-level [`Blackboard`] to the generated task.
+    ///
+    /// Every step receives it through its [`TaskContext`]
+    /// ([`ctx.blackboard()`](TaskContext::blackboard)), so steps can share state across
+    /// runs without capturing their own clone. Attaching the *same* blackboard to
+    /// several tasks lets those tasks share data. If not set, each task gets a fresh,
+    /// empty blackboard.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tasklet::task::TaskStepStatusOk::Success;
+    /// # use tasklet::{Blackboard, TaskBuilder};
+    /// let board = Blackboard::new();
+    /// let _task = TaskBuilder::new(chrono::Local)
+    ///     .every("* * * * * * *")
+    ///     .blackboard(board.clone())
+    ///     .add_step("use it", |ctx| async move {
+    ///         let n: u32 = ctx.blackboard().get_or_insert("runs", 0);
+    ///         ctx.blackboard().set("runs", n + 1);
+    ///         Ok(Success)
+    ///     })
+    ///     .build();
+    /// ```
+    pub fn blackboard(mut self, blackboard: Blackboard) -> TaskBuilder<T> {
+        self.blackboard = Some(blackboard);
+        self
+    }
+
     pub fn overlap(mut self, overlap: OverlapPolicy) -> TaskBuilder<T> {
         self.overlap = overlap;
         self
@@ -433,14 +466,18 @@ where
     ///
     /// # Examples
     ///
+    /// Each step is handed a [`TaskContext`] identifying the run and giving access to
+    /// the task-level [`Blackboard`] and a per-run store; ignore it with `|_ctx|` if the
+    /// step does not need it.
+    ///
     /// ```rust
     /// # use tasklet::task::TaskStepStatusErr::Error;
     /// # use tasklet::TaskBuilder;
-    /// let _ = TaskBuilder::new(chrono::Utc).add_step("A step that fails.", || async { Err(Error) });
+    /// let _ = TaskBuilder::new(chrono::Utc).add_step("A step that fails.", |_ctx| async { Err(Error) });
     /// ```
     pub fn add_step<F, Fut>(mut self, description: &str, function: F) -> TaskBuilder<T>
     where
-        F: (FnMut() -> Fut) + Send + 'static,
+        F: (FnMut(TaskContext) -> Fut) + Send + 'static,
         Fut: std::future::Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>>
             + Send
             + 'static,
@@ -458,11 +495,11 @@ where
     /// ```
     /// # use tasklet::task::TaskStepStatusOk::Success;
     /// use tasklet::TaskBuilder;
-    /// let _ = TaskBuilder::new(chrono::Local).add_step_default(|| async { Ok(Success) });
+    /// let _ = TaskBuilder::new(chrono::Local).add_step_default(|_ctx| async { Ok(Success) });
     /// ```
     pub fn add_step_default<F, Fut>(mut self, function: F) -> TaskBuilder<T>
     where
-        F: (FnMut() -> Fut) + 'static + Send,
+        F: (FnMut(TaskContext) -> Fut) + 'static + Send,
         Fut: std::future::Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>>
             + Send
             + 'static,
@@ -522,6 +559,11 @@ where
             task.set_retry_policy(policy);
         }
         task.set_overlap(self.overlap);
+
+        // Attach the task-level blackboard, if one was provided.
+        if let Some(blackboard) = self.blackboard {
+            task.set_blackboard(blackboard);
+        }
 
         // Transfer the lifecycle callbacks.
         task.set_callbacks(self.on_success, self.on_failure, self.on_finish);
@@ -599,7 +641,7 @@ mod test {
     /// Test the normal functionality of the add_step() function of the `TaskBuilder`.
     #[test]
     pub fn test_task_builder_add_step() {
-        let builder = TaskBuilder::new(chrono::Utc).add_step_default(|| async { Ok(Success) });
+        let builder = TaskBuilder::new(chrono::Utc).add_step_default(|_ctx| async { Ok(Success) });
         assert_eq!(builder.timezone, chrono::Utc);
         assert_eq!(builder.steps.len(), 1);
     }
@@ -611,7 +653,7 @@ mod test {
             .every("* * * * * * *")
             .repeat(5)
             .description("Some description")
-            .add_step("Step 1", || async { Ok(Success) })
+            .add_step("Step 1", |_ctx| async { Ok(Success) })
             .build()
             .unwrap();
         assert_some!(task.repeats);
@@ -625,7 +667,7 @@ mod test {
     pub fn test_task_builder_build_default() {
         let task = TaskBuilder::new(chrono::Utc)
             .repeat(5)
-            .add_step("Step 1", || async { Ok(Success) })
+            .add_step("Step 1", |_ctx| async { Ok(Success) })
             .build()
             .unwrap();
         assert_some!(task.repeats);
@@ -722,5 +764,27 @@ mod test {
         // Second 60 is out of range, so the generated expression is invalid.
         let result = TaskBuilder::new(chrono::Utc).every_seconds(60).build();
         assert!(matches!(result, Err(TaskError::InvalidCronExpression(_))));
+    }
+
+    /// A blackboard attached via the builder reaches the step's context. (0.5.0)
+    #[tokio::test]
+    async fn test_builder_blackboard_reaches_step_context() {
+        let board = Blackboard::new();
+        board.set("seed", 41u32);
+        let mut task = TaskBuilder::new(chrono::Local)
+            .every("* * * * * * *")
+            .blackboard(board.clone())
+            .add_step("bump", |ctx| async move {
+                let seed: u32 = ctx.blackboard().get("seed").unwrap_or(0);
+                ctx.blackboard().set("seed", seed + 1);
+                Ok(Success)
+            })
+            .build()
+            .unwrap();
+        task.set_id(0);
+        task.init();
+        assert!(task.run_task(0).await.is_ok());
+        // The step saw the attached blackboard and wrote back through it.
+        assert_eq!(board.get::<u32>("seed"), Some(42));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@
 //!
 //! * **Async steps** — every task step is a closure returning a future, so steps can
 //!   `.await` real asynchronous work (I/O, timers, ...) without blocking the runtime.
+//!   Each step is handed a [`TaskContext`] identifying the run (task id/name, run id,
+//!   step index, attempt) and giving access to a task-level [`Blackboard`] plus a
+//!   per-run store for passing values between steps within a run.
 //! * **Graceful shutdown** — obtain a [`SchedulerHandle`] via
 //!   [`TaskScheduler::handle`] before running and call `shutdown()` to stop the scheduler
 //!   cleanly, or drive shutdown with any future via [`TaskScheduler::run_until`].
@@ -29,6 +32,8 @@
 //!   [`TaskScheduler::add_task_get_id`].
 //! * **Runtime control** — name a task with [`TaskBuilder::name`] and pause, resume,
 //!   trigger or remove it at runtime through a [`SchedulerHandle`], by id or by name.
+//!   Add tasks to a running scheduler with a [`TaskSpawner`] obtained from
+//!   [`TaskScheduler::spawner`].
 //! * **Shared data** — pass values between tasks and steps with a cheaply-clonable,
 //!   typed [`Blackboard`].
 //!
@@ -45,7 +50,7 @@
 //!         TaskBuilder::new(chrono::Local)
 //!             .every("1 * * * * * *")
 //!             .description("A simple task")
-//!             .add_step("Step 1", || async { Ok(Success) })
+//!             .add_step("Step 1", |_ctx| async { Ok(Success) })
 //!             .build(),
 //!     );
 //!     scheduler.run().await;
@@ -65,8 +70,10 @@ pub use builders::TaskBuilder;
 pub use errors::{TaskError, TaskResult};
 pub use generator::TaskGenerator;
 pub use retry::{Backoff, Jitter, RetryPolicy};
-pub use scheduler::{SchedulerHandle, TaskScheduler, TaskState};
-pub use task::{OverlapPolicy, RunOutcome, RunRecord, Status, StepState, StepStatus, Task};
+pub use scheduler::{SchedulerHandle, TaskScheduler, TaskSpawner, TaskState};
+pub use task::{
+    OverlapPolicy, RunOutcome, RunRecord, Status, StepState, StepStatus, Task, TaskContext,
+};
 
 /// Macro for consistent task-related logging
 ///

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -10,8 +10,115 @@ use std::future::Future;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::{mpsc, Notify};
+use tokio::sync::{mpsc, oneshot, Notify};
 use tokio::task::JoinHandle;
+
+/// A request sent from a [`TaskSpawner`] to a running scheduler asking it to add a task.
+///
+/// The optional `reply` channel carries the assigned id (or the rejection error) back
+/// to the caller of [`TaskSpawner::spawn_get_id`].
+struct SpawnRequest<T>
+where
+    T: TimeZone + Clone + Send + 'static,
+{
+    task: Task<T>,
+    reply: Option<oneshot::Sender<Result<usize, TaskError>>>,
+}
+
+/// A cloneable handle for adding tasks to a *running* [`TaskScheduler`] at runtime.
+///
+/// The type-erased [`SchedulerHandle`] cannot add tasks because a `Task<T>` carries the
+/// scheduler's timezone type `T` and its step closures. A `TaskSpawner<T>` keeps that
+/// type, so it can hand fully-built tasks to the scheduler from anywhere (another task,
+/// an API handler, a signal handler). Obtain one with [`TaskScheduler::spawner`] before
+/// calling [`run`](TaskScheduler::run).
+///
+/// Spawned tasks are picked up on the next scheduler round, so they are only processed
+/// while the scheduler is running (like tasks produced by a
+/// [`TaskGenerator`](crate::TaskGenerator)).
+///
+/// # Examples
+///
+/// ```
+/// # use tasklet::{TaskBuilder, TaskScheduler};
+/// # use std::time::Duration;
+/// # tokio_test::block_on(async {
+/// let mut scheduler = TaskScheduler::new(50, chrono::Local);
+/// let spawner = scheduler.spawner();
+///
+/// // Add a task from another task once the scheduler is running.
+/// tokio::spawn(async move {
+///     let _ = spawner.spawn(
+///         TaskBuilder::new(chrono::Local)
+///             .every("* * * * * * *")
+///             .add_step_default(|_ctx| async { Ok(tasklet::task::TaskStepStatusOk::Success) })
+///             .build(),
+///     );
+/// });
+///
+/// scheduler.run_until(tokio::time::sleep(Duration::from_millis(150))).await;
+/// # });
+/// ```
+pub struct TaskSpawner<T>
+where
+    T: TimeZone + Clone + Send + 'static,
+{
+    tx: mpsc::UnboundedSender<SpawnRequest<T>>,
+}
+
+// A manual `Clone` avoids an unnecessary `T: Clone` bound the derive would add: the
+// only field is an `UnboundedSender`, which is always cloneable.
+impl<T> Clone for TaskSpawner<T>
+where
+    T: TimeZone + Clone + Send + 'static,
+{
+    fn clone(&self) -> Self {
+        TaskSpawner {
+            tx: self.tx.clone(),
+        }
+    }
+}
+
+impl<T> TaskSpawner<T>
+where
+    T: TimeZone + Clone + Send + 'static,
+    <T as TimeZone>::Offset: Send,
+{
+    /// Queue a task to be added on the scheduler's next round.
+    ///
+    /// A build error in `task` is returned immediately. The task is otherwise queued
+    /// fire-and-forget; if it carries a name that collides with an existing task it is
+    /// rejected on the scheduler side (observable via the handle rather than here). Use
+    /// [`spawn_get_id`](Self::spawn_get_id) to await the assigned id or the rejection.
+    ///
+    /// Returns [`TaskError::ExecutionError`] if the scheduler has already stopped.
+    pub fn spawn(&self, task: TaskResult<Task<T>>) -> TaskResult<()> {
+        let task = task?;
+        self.tx
+            .send(SpawnRequest { task, reply: None })
+            .map_err(|_| TaskError::ExecutionError("scheduler is no longer running".to_string()))
+    }
+
+    /// Queue a task and await the id the scheduler assigns it.
+    ///
+    /// Resolves once the scheduler processes the request on its next round. A build
+    /// error is returned immediately; a duplicate name is reported as
+    /// [`TaskError::DuplicateTaskName`]; a stopped scheduler as
+    /// [`TaskError::ExecutionError`].
+    pub async fn spawn_get_id(&self, task: TaskResult<Task<T>>) -> TaskResult<usize> {
+        let task = task?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(SpawnRequest {
+                task,
+                reply: Some(reply_tx),
+            })
+            .map_err(|_| TaskError::ExecutionError("scheduler is no longer running".to_string()))?;
+        reply_rx.await.map_err(|_| {
+            TaskError::ExecutionError("scheduler dropped the spawn request".to_string())
+        })?
+    }
+}
 
 /// Handler for a running task.
 ///
@@ -307,6 +414,10 @@ where
     /// The observable/controllable registry, rebuilt each round and shared with every
     /// [`SchedulerHandle`].
     registry: Arc<Mutex<Vec<RegEntry>>>,
+    /// Sender cloned into every [`TaskSpawner`] handed out via [`spawner`](Self::spawner).
+    spawn_tx: mpsc::UnboundedSender<SpawnRequest<T>>,
+    /// Receiver drained each round for tasks queued by a [`TaskSpawner`].
+    spawn_rx: mpsc::UnboundedReceiver<SpawnRequest<T>>,
 }
 
 /// `TaskScheduler` implementation.
@@ -328,6 +439,7 @@ where
     /// let _ = TaskScheduler::default(chrono::Utc);
     /// ```
     pub fn default(timezone: T) -> TaskScheduler<T> {
+        let (spawn_tx, spawn_rx) = mpsc::unbounded_channel();
         TaskScheduler {
             handles: Vec::new(),
             /* Originally empty, no registered tasks. */
@@ -337,6 +449,8 @@ where
             next_id: 0,
             shutdown: Arc::new(Notify::new()),
             registry: Arc::new(Mutex::new(Vec::new())),
+            spawn_tx,
+            spawn_rx,
         }
     }
 
@@ -353,6 +467,26 @@ where
         SchedulerHandle {
             notify: self.shutdown.clone(),
             registry: self.registry.clone(),
+        }
+    }
+
+    /// Return a cloneable [`TaskSpawner`] that can add tasks to this scheduler while it
+    /// is running.
+    ///
+    /// Unlike [`SchedulerHandle`], a spawner keeps the scheduler's timezone type `T`, so
+    /// it can hand fully-built `Task<T>` values to the running loop. Obtain it before
+    /// calling [`run`](Self::run); queued tasks are added on the next round.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tasklet::TaskScheduler;
+    /// let scheduler = TaskScheduler::default(chrono::Utc);
+    /// let _spawner = scheduler.spawner();
+    /// ```
+    pub fn spawner(&self) -> TaskSpawner<T> {
+        TaskSpawner {
+            tx: self.spawn_tx.clone(),
         }
     }
 
@@ -483,7 +617,24 @@ where
 
         // Increase the id of the next task.
         self.next_id += 1;
+
+        // Publish the new task into the shared registry immediately so a
+        // `SchedulerHandle` can observe and control it before `run()` is called, not
+        // only after the first scheduling round.
+        self.refresh_registry();
         Ok(id)
+    }
+
+    /// Add every task queued by a [`TaskSpawner`] since the last round, replying with the
+    /// assigned id (or the rejection error) to any caller awaiting one.
+    fn drain_spawns(&mut self) {
+        while let Ok(request) = self.spawn_rx.try_recv() {
+            let result = self.add_task_get_id(Ok(request.task));
+            if let Some(reply) = request.reply {
+                // The receiver may have gone away; that is fine.
+                let _ = reply.send(result);
+            }
+        }
     }
 
     /// Run a single scheduling round.
@@ -602,6 +753,7 @@ where
     /// dispatch the current round. Newly generated tasks initialize themselves.
     fn tick(&mut self) {
         self.run_task_gen();
+        self.drain_spawns();
         self.dispatch_round();
     }
 
@@ -714,7 +866,7 @@ mod test {
         let c = counter.clone();
         let mut builder = TaskBuilder::new(Local)
             .every("* * * * * * *")
-            .add_step_default(move || {
+            .add_step_default(move |_ctx| {
                 let c = c.clone();
                 async move {
                     c.fetch_add(1, Ordering::SeqCst);
@@ -777,7 +929,7 @@ mod test {
         let s = slow.clone();
         let slow_task = TaskBuilder::new(Local)
             .every("* * * * * * *")
-            .add_step_default(move || {
+            .add_step_default(move |_ctx| {
                 let s = s.clone();
                 async move {
                     s.fetch_add(1, Ordering::SeqCst);
@@ -882,7 +1034,7 @@ mod test {
         let mut scheduler = TaskScheduler::new(100, Local);
 
         let mut doomed = Task::new("* * * * * * *", None, None, Local).unwrap();
-        doomed.add_step_default(|| async { Err(ErrorDelete) });
+        doomed.add_step_default(|_ctx| async { Err(ErrorDelete) });
         scheduler.add_task(Ok(doomed)).unwrap();
         scheduler.add_task(counting_task(&survivor, None)).unwrap();
 
@@ -1031,8 +1183,9 @@ mod test {
             .unwrap();
 
         let handle = scheduler.handle();
-        // Before running, the snapshot is empty.
-        assert_eq!(handle.task_count(), 0);
+        // The registry is populated at `add_task` time, so both tasks are visible
+        // through the handle before `run()` is ever called.
+        assert_eq!(handle.task_count(), 2);
 
         let probe = handle.clone();
         let observer = tokio::spawn(async move {
@@ -1238,7 +1391,7 @@ mod test {
         let task = TaskBuilder::new(Local)
             .every("* * * * * * *")
             .name("worker")
-            .add_step("do work", move || {
+            .add_step("do work", move |_ctx| {
                 let c = c.clone();
                 async move {
                     c.fetch_add(1, Ordering::SeqCst);
@@ -1289,7 +1442,7 @@ mod test {
         let task = TaskBuilder::new(Local)
             .every("* * * * * * *")
             .name("named")
-            .add_step_default(move || {
+            .add_step_default(move |_ctx| {
                 let c = c.clone();
                 async move {
                     c.fetch_add(1, Ordering::SeqCst);
@@ -1338,5 +1491,100 @@ mod test {
         assert!(back.paused);
         assert_eq!(back.last_outcome, Some(RunOutcome::Success));
         assert_eq!(back.run_count, 5);
+    }
+
+    /// A `TaskSpawner` adds a task to a running scheduler, which then executes it. (0.5.0)
+    #[tokio::test]
+    async fn test_spawner_adds_task_at_runtime() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut scheduler = TaskScheduler::new(100, Local);
+        let spawner = scheduler.spawner();
+        let handle = scheduler.handle();
+
+        // Nothing registered up front.
+        assert_eq!(handle.task_count(), 0);
+
+        let c = counter.clone();
+        let injector = tokio::spawn(async move {
+            // Let the scheduler start, then inject a task from outside.
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            let task = TaskBuilder::new(Local)
+                .every("* * * * * * *")
+                .add_step_default(move |_ctx| {
+                    let c = c.clone();
+                    async move {
+                        c.fetch_add(1, Ordering::SeqCst);
+                        Ok(Success)
+                    }
+                })
+                .build();
+            spawner.spawn(task).expect("spawn should be accepted");
+        });
+
+        scheduler
+            .run_until(tokio::time::sleep(Duration::from_millis(1500)))
+            .await;
+        injector.await.unwrap();
+
+        assert!(
+            counter.load(Ordering::SeqCst) >= 1,
+            "spawned task should have executed at least once"
+        );
+    }
+
+    /// `spawn_get_id` resolves with the id the scheduler assigns the task. (0.5.0)
+    #[tokio::test]
+    async fn test_spawner_get_id_returns_assigned_id() {
+        let mut scheduler = TaskScheduler::new(50, Local);
+        // Pre-register one task so the next assigned id is 1.
+        scheduler
+            .add_task(Task::new("* * * * * * *", None, None, Local))
+            .unwrap();
+        let spawner = scheduler.spawner();
+
+        let getter = tokio::spawn(async move {
+            let task = TaskBuilder::new(Local).every("* * * * * * *").build();
+            spawner.spawn_get_id(task).await
+        });
+
+        scheduler
+            .run_until(tokio::time::sleep(Duration::from_millis(400)))
+            .await;
+
+        let id = getter.await.unwrap().expect("spawn_get_id should succeed");
+        assert_eq!(id, 1, "the injected task should be assigned the next id");
+    }
+
+    /// A spawned task whose name collides with an existing one is rejected. (0.5.0)
+    #[tokio::test]
+    async fn test_spawner_rejects_duplicate_name() {
+        let mut scheduler = TaskScheduler::new(50, Local);
+        scheduler
+            .add_task(
+                TaskBuilder::new(Local)
+                    .every("* * * * * * *")
+                    .name("dup")
+                    .build(),
+            )
+            .unwrap();
+        let spawner = scheduler.spawner();
+
+        let getter = tokio::spawn(async move {
+            let task = TaskBuilder::new(Local)
+                .every("* * * * * * *")
+                .name("dup")
+                .build();
+            spawner.spawn_get_id(task).await
+        });
+
+        scheduler
+            .run_until(tokio::time::sleep(Duration::from_millis(400)))
+            .await;
+
+        let result = getter.await.unwrap();
+        assert!(
+            matches!(result, Err(TaskError::DuplicateTaskName(name)) if name == "dup"),
+            "a duplicate name must be rejected on the scheduler side"
+        );
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,6 +1,7 @@
 extern crate chrono;
 extern crate cron;
 
+use crate::blackboard::Blackboard;
 use crate::errors::{TaskError, TaskResult};
 use crate::retry::RetryPolicy;
 use crate::{step_log, task_log};
@@ -46,8 +47,109 @@ pub type StepFuture =
 
 /// An executable, asynchronous function.
 ///
-/// Each call produces a fresh [`StepFuture`] to be awaited.
-pub type ExecutableFn = dyn FnMut() -> StepFuture + 'static + Send;
+/// Each call is handed a [`TaskContext`] for the current attempt and produces a fresh
+/// [`StepFuture`] to be awaited.
+pub type ExecutableFn = dyn FnMut(TaskContext) -> StepFuture + 'static + Send;
+
+/// The execution context handed to a step each time it runs.
+///
+/// A `TaskContext` identifies the run (which task, which run, which step, which attempt)
+/// and gives the step access to two typed key/value stores:
+///
+/// * [`blackboard`](TaskContext::blackboard) - the task-level [`Blackboard`], shared
+///   across every run of the task and, if the same blackboard is attached to several
+///   tasks via [`TaskBuilder::blackboard`](crate::TaskBuilder::blackboard), across those
+///   tasks too. Use it for state that must outlive a single run.
+/// * [`run_store`](TaskContext::run_store) - a fresh [`Blackboard`] created for each run,
+///   so steps can hand values to later steps within the same run without leaking them
+///   into the next run (an XCom-like scratchpad).
+///
+/// The context is cheap to clone (both stores are `Arc`-backed); it is moved into the
+/// step's future, so a step can keep it for the duration of its async work.
+///
+/// # Examples
+///
+/// ```
+/// use tasklet::task::TaskStepStatusOk::Success;
+/// use tasklet::TaskBuilder;
+///
+/// let _task = TaskBuilder::new(chrono::Local)
+///     .every("* * * * * * *")
+///     .add_step("produce", |ctx| async move {
+///         ctx.run_store().set("value", 21u32);
+///         Ok(Success)
+///     })
+///     .add_step("consume", |ctx| async move {
+///         let doubled = ctx.run_store().get::<u32>("value").unwrap_or(0) * 2;
+///         assert_eq!(doubled, 42);
+///         Ok(Success)
+///     })
+///     .build();
+/// ```
+#[derive(Clone)]
+pub struct TaskContext {
+    task_id: usize,
+    task_name: Option<Arc<str>>,
+    run_id: usize,
+    step_index: usize,
+    attempt: u32,
+    blackboard: Blackboard,
+    run_store: Blackboard,
+}
+
+impl TaskContext {
+    /// The id the scheduler assigned to the running task.
+    pub fn task_id(&self) -> usize {
+        self.task_id
+    }
+
+    /// The task's unique name, if one was set via
+    /// [`TaskBuilder::name`](crate::TaskBuilder::name).
+    pub fn task_name(&self) -> Option<&str> {
+        self.task_name.as_deref()
+    }
+
+    /// The id of the current run (monotonically increasing per task).
+    pub fn run_id(&self) -> usize {
+        self.run_id
+    }
+
+    /// The zero-based index of the step this context was handed to.
+    pub fn step_index(&self) -> usize {
+        self.step_index
+    }
+
+    /// The current attempt number for this step, starting at 1. Values above 1 mean an
+    /// earlier attempt failed and is being retried under the task's
+    /// [`RetryPolicy`].
+    pub fn attempt(&self) -> u32 {
+        self.attempt
+    }
+
+    /// The task-level [`Blackboard`], shared across runs (and across tasks that share
+    /// the same blackboard).
+    pub fn blackboard(&self) -> &Blackboard {
+        &self.blackboard
+    }
+
+    /// A per-run [`Blackboard`], created fresh for each run, for handing values between
+    /// steps within a single run.
+    pub fn run_store(&self) -> &Blackboard {
+        &self.run_store
+    }
+}
+
+impl fmt::Debug for TaskContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TaskContext")
+            .field("task_id", &self.task_id)
+            .field("task_name", &self.task_name)
+            .field("run_id", &self.run_id)
+            .field("step_index", &self.step_index)
+            .field("attempt", &self.attempt)
+            .finish_non_exhaustive()
+    }
+}
 
 /// The boxed future produced by a lifecycle callback when it is invoked.
 pub type CallbackFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
@@ -97,16 +199,16 @@ impl TaskStep {
     ///
     /// ```
     /// # use tasklet::task::{TaskStep, TaskStepStatusOk};
-    /// let _ = TaskStep::new("Some task", || async { Ok(TaskStepStatusOk::Success) });
+    /// let _ = TaskStep::new("Some task", |_ctx| async { Ok(TaskStepStatusOk::Success) });
     /// ```
     pub fn new<F, Fut>(description: &str, mut function: F) -> Self
     where
-        F: (FnMut() -> Fut) + 'static + Send,
+        F: (FnMut(TaskContext) -> Fut) + 'static + Send,
         Fut: Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>> + Send + 'static,
     {
         Self {
             description: Some(description.to_string()),
-            function: Box::new(move || Box::pin(function())),
+            function: Box::new(move |ctx| Box::pin(function(ctx))),
         }
     }
 
@@ -121,15 +223,15 @@ impl TaskStep {
     /// ```
     /// # use tasklet::task::TaskStep;
     /// use tasklet::task::TaskStepStatusOk::Success;
-    /// let _ = TaskStep::default(|| async { Ok(Success) });
+    /// let _ = TaskStep::default(|_ctx| async { Ok(Success) });
     /// ```
     pub fn default<F, Fut>(mut function: F) -> Self
     where
-        F: (FnMut() -> Fut) + 'static + Send,
+        F: (FnMut(TaskContext) -> Fut) + 'static + Send,
         Fut: Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>> + Send + 'static,
     {
         Self {
-            function: Box::new(move || Box::pin(function())),
+            function: Box::new(move |ctx| Box::pin(function(ctx))),
             description: None,
         }
     }
@@ -387,6 +489,11 @@ where
     pub(crate) on_finish: Option<Box<CallbackFn>>,
     /// Behaviour when a scheduled run overlaps a still-running one.
     pub(crate) overlap: OverlapPolicy,
+    /// The task-level shared store handed to every step through its [`TaskContext`].
+    /// Defaults to a fresh, empty [`Blackboard`]; attach a shared one via
+    /// [`TaskBuilder::blackboard`](crate::TaskBuilder::blackboard) to pass data across
+    /// tasks.
+    pub(crate) blackboard: Blackboard,
 }
 
 impl<T> Debug for Task<T>
@@ -466,6 +573,7 @@ where
             on_failure: None,
             on_finish: None,
             overlap: OverlapPolicy::default(),
+            blackboard: Blackboard::new(),
         })
     }
 
@@ -502,7 +610,7 @@ where
     #[cfg(test)]
     pub(crate) fn add_step<F, Fut>(&mut self, description: &str, function: F) -> &mut Task<T>
     where
-        F: (FnMut() -> Fut) + 'static + Send,
+        F: (FnMut(TaskContext) -> Fut) + 'static + Send,
         Fut: Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>> + Send + 'static,
     {
         self.steps.push(TaskStep::new(description, function));
@@ -517,7 +625,7 @@ where
     #[cfg(test)]
     pub(crate) fn add_step_default<F, Fut>(&mut self, function: F) -> &mut Task<T>
     where
-        F: (FnMut() -> Fut) + 'static + Send,
+        F: (FnMut(TaskContext) -> Fut) + 'static + Send,
         Fut: Future<Output = Result<TaskStepStatusOk, TaskStepStatusErr>> + Send + 'static,
     {
         self.steps.push(TaskStep::default(function));
@@ -571,6 +679,13 @@ where
     /// Set the maximum number of run records retained for this task.
     pub(crate) fn set_history_limit(&mut self, limit: usize) -> &mut Task<T> {
         self.history_limit = limit;
+        self
+    }
+
+    /// Attach a task-level [`Blackboard`], shared with every step through its
+    /// [`TaskContext`].
+    pub(crate) fn set_blackboard(&mut self, blackboard: Blackboard) -> &mut Task<T> {
+        self.blackboard = blackboard;
         self
     }
 
@@ -649,8 +764,8 @@ where
     /// Run the task's steps and fire the success/failure callbacks based on the
     /// outcome. `on_finish` is fired here only for the terminal `ForceRemoved` state
     /// (a normally-finishing task fires it from [`Task::reschedule_and_notify`]).
-    pub(crate) async fn run_and_notify(&mut self) {
-        let _ = self.run_task().await; // status is updated in place; the result is redundant
+    pub(crate) async fn run_and_notify(&mut self, run_id: usize) {
+        let _ = self.run_task(run_id).await; // status is updated in place; the result is redundant
         match self.status {
             Status::Executed => Self::fire_callback(&mut self.on_success).await,
             Status::Failed => Self::fire_callback(&mut self.on_failure).await,
@@ -704,7 +819,10 @@ where
     }
 
     /// Run the task and handle the output.
-    pub(crate) async fn run_task(&mut self) -> TaskResult<()> {
+    ///
+    /// `run_id` identifies the current run and is surfaced to each step through its
+    /// [`TaskContext`].
+    pub(crate) async fn run_task(&mut self, run_id: usize) -> TaskResult<()> {
         match &self.status {
             Status::Init => Err(TaskError::NotInitialized),
             Status::Failed => Err(TaskError::Failed),
@@ -730,6 +848,13 @@ where
                 // Stream the fresh (all-pending) snapshot so observers see the run begin.
                 self.publish_steps();
 
+                // A fresh per-run store for step-to-step data flow, plus the task
+                // identity captured once so building each attempt's context is cheap.
+                let run_store = Blackboard::new();
+                let task_name: Option<Arc<str>> = self.name.as_deref().map(Arc::from);
+                let task_id = self.task_id;
+                let blackboard = self.blackboard.clone();
+
                 let mut had_error: bool = false;
                 // Iterate by index so `self` is free between step invocations, letting us
                 // stream each transition to the shared cell as it happens.
@@ -748,6 +873,19 @@ where
                         attempt += 1;
                         self.last_attempts += 1;
 
+                        // The context handed to the step for this attempt. Cheap to
+                        // build: the stores are `Arc`-backed clones and the name is a
+                        // shared `Arc<str>`.
+                        let ctx = TaskContext {
+                            task_id,
+                            task_name: task_name.clone(),
+                            run_id,
+                            step_index: index,
+                            attempt,
+                            blackboard: blackboard.clone(),
+                            run_store: run_store.clone(),
+                        };
+
                         // Run the step, optionally bounded by the configured timeout.
                         // A timeout is treated as a (retryable) `Error`. Producing the
                         // step future borrows `self.steps[index]` only until it returns;
@@ -755,8 +893,11 @@ where
                         // await and `self` is free afterwards.
                         let result = match timeout {
                             Some(duration) => {
-                                match tokio::time::timeout(duration, (self.steps[index].function)())
-                                    .await
+                                match tokio::time::timeout(
+                                    duration,
+                                    (self.steps[index].function)(ctx),
+                                )
+                                .await
                                 {
                                     Ok(result) => result,
                                     Err(_) => {
@@ -772,7 +913,7 @@ where
                                     }
                                 }
                             }
-                            None => (self.steps[index].function)().await,
+                            None => (self.steps[index].function)(ctx).await,
                         };
 
                         match result {
@@ -951,7 +1092,7 @@ where
 {
     let run_id = shared.start_run(Utc::now());
     shared.running.store(true, Ordering::SeqCst);
-    task.run_and_notify().await;
+    task.run_and_notify(run_id).await;
     // Capture the outcome before `reschedule` overwrites the status.
     let outcome = task.run_outcome();
     task.reschedule_and_notify().await;
@@ -1016,16 +1157,16 @@ mod test {
     #[tokio::test]
     async fn normal_task_flow_test() {
         let mut task = Task::new("* * * * * *", Some("Test task"), Some(2), Local).unwrap();
-        task.add_step_default(|| async { Ok(Success) });
+        task.add_step_default(|_ctx| async { Ok(Success) });
         assert_eq!(task.status, Status::Init);
         task.set_id(0);
         task.init();
         assert_eq!(task.status, Status::Scheduled);
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::Executed);
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Scheduled);
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::Executed);
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Finished);
@@ -1036,7 +1177,7 @@ mod test {
         let schedule: Schedule = "* * * * * * *".parse().unwrap();
         let mut task = Task::new("* * * * * * *", None, None, Local).unwrap();
         task.set_schedule(schedule);
-        task.add_step_default(|| async { Ok(Success) });
+        task.add_step_default(|_ctx| async { Ok(Success) });
         assert_eq!(task.status, Status::Init);
         task.set_id(0);
         task.init();
@@ -1046,16 +1187,16 @@ mod test {
     #[tokio::test]
     async fn normal_task_error_flow_test() {
         let mut task = Task::new("* * * * * *", Some("Test task"), Some(2), Local).unwrap();
-        task.add_step_default(|| async { Err(Error) });
+        task.add_step_default(|_ctx| async { Err(Error) });
         assert_eq!(task.status, Status::Init);
         task.set_id(0);
         task.init();
         assert_eq!(task.status, Status::Scheduled);
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::Failed);
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Scheduled);
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::Failed);
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Finished);
@@ -1065,14 +1206,14 @@ mod test {
     #[tokio::test]
     async fn normal_task_no_fixed_repeats_test() {
         let mut task = Task::new("* * * * * * *", Some("Test task"), None, Local).unwrap();
-        task.add_step_default(|| async { Ok(Success) });
+        task.add_step_default(|_ctx| async { Ok(Success) });
         assert_eq!(task.status, Status::Init);
         task.set_id(0);
         task.init();
         assert_eq!(task.status, Status::Scheduled);
         // Run it for a few times.
         for _i in 1..10 {
-            assert!(task.run_task().await.is_ok());
+            assert!(task.run_task(0).await.is_ok());
             assert_eq!(task.status, Status::Executed);
             assert!(task.reschedule().is_ok());
             assert_eq!(task.status, Status::Scheduled);
@@ -1096,7 +1237,7 @@ mod test {
         // Execute the task.
         task.set_id(0);
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Finished);
     }
@@ -1104,9 +1245,9 @@ mod test {
     #[tokio::test]
     async fn test_run_uninitialized_task() {
         let mut task = Task::new("* * * * * * *", None, None, Local).unwrap();
-        assert!(task.run_task().await.is_err());
+        assert!(task.run_task(0).await.is_err());
         assert!(matches!(
-            task.run_task().await.unwrap_err(),
+            task.run_task(0).await.unwrap_err(),
             TaskError::NotInitialized
         ));
     }
@@ -1114,15 +1255,15 @@ mod test {
     #[tokio::test]
     async fn test_run_failed_task() {
         let mut task = Task::new("* * * * * * *", None, None, Local).unwrap();
-        task.add_step_default(|| async { Err(Error) });
+        task.add_step_default(|_ctx| async { Err(Error) });
         task.set_id(0);
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::Failed);
         // Attempt to rerun it, it should fail.
-        assert!(task.run_task().await.is_err());
+        assert!(task.run_task(0).await.is_err());
         assert!(matches!(
-            task.run_task().await.unwrap_err(),
+            task.run_task(0).await.unwrap_err(),
             TaskError::Failed
         ));
     }
@@ -1130,15 +1271,15 @@ mod test {
     #[tokio::test]
     async fn test_run_executed_task() {
         let mut task = Task::new("* * * * * * *", None, None, Local).unwrap();
-        task.add_step("Step 1", || async { Ok(Success) });
+        task.add_step("Step 1", |_ctx| async { Ok(Success) });
         task.set_id(0);
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::Executed);
         // Attempt to run it again, it should fail.
-        assert!(task.run_task().await.is_err());
+        assert!(task.run_task(0).await.is_err());
         assert!(matches!(
-            task.run_task().await.unwrap_err(),
+            task.run_task(0).await.unwrap_err(),
             TaskError::AlreadyExecuted
         ));
     }
@@ -1148,13 +1289,13 @@ mod test {
         let mut task = Task::new("* * * * * * *", None, Some(1), Local).unwrap();
         task.set_id(0);
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert!(task.reschedule().is_ok());
         assert_eq!(task.status, Status::Finished);
         // At this point the task is Finished. It should not be allowed to run again.
-        assert!(task.run_task().await.is_err());
+        assert!(task.run_task(0).await.is_err());
         assert!(matches!(
-            task.run_task().await.unwrap_err(),
+            task.run_task(0).await.unwrap_err(),
             TaskError::Finished
         ));
     }
@@ -1162,10 +1303,10 @@ mod test {
     #[tokio::test]
     async fn test_run_failed_delete() {
         let mut task = Task::new("* * * * * * *", None, None, Local).unwrap();
-        task.add_step_default(|| async { Err(ErrorDelete) });
+        task.add_step_default(|_ctx| async { Err(ErrorDelete) });
         task.set_id(0);
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::ForceRemoved);
     }
 
@@ -1197,10 +1338,10 @@ mod test {
         assert_eq!(task.status, Status::Scheduled);
 
         // Add a step that succeeds
-        task.add_step_default(|| async { Ok(TaskStepStatusOk::Success) });
+        task.add_step_default(|_ctx| async { Ok(TaskStepStatusOk::Success) });
 
         // After run_task(), status should be Executed
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::Executed);
 
         // After reschedule(), with repeats=1 and already executed once,
@@ -1212,15 +1353,16 @@ mod test {
     #[test]
     fn test_task_step_display() {
         // Test with description
-        let step_with_desc = TaskStep::new("Test step", || async { Ok(TaskStepStatusOk::Success) });
+        let step_with_desc =
+            TaskStep::new("Test step", |_ctx| async { Ok(TaskStepStatusOk::Success) });
         assert_eq!(format!("{}", step_with_desc), "Test step");
 
         // Test without description
-        let step_no_desc = TaskStep::default(|| async { Ok(TaskStepStatusOk::Success) });
+        let step_no_desc = TaskStep::default(|_ctx| async { Ok(TaskStepStatusOk::Success) });
         assert_eq!(format!("{}", step_no_desc), "-");
 
         // Test with empty description
-        let step_empty_desc = TaskStep::new("", || async { Ok(TaskStepStatusOk::Success) });
+        let step_empty_desc = TaskStep::new("", |_ctx| async { Ok(TaskStepStatusOk::Success) });
         assert_eq!(format!("{}", step_empty_desc), "-");
     }
 
@@ -1228,13 +1370,13 @@ mod test {
     async fn test_run_and_reschedule_notify() {
         let mut task = Task::new("* * * * * * *", Some("Notify flow"), Some(1), Utc).unwrap();
         task.set_id(1);
-        task.add_step("Test step", || async { Ok(TaskStepStatusOk::Success) });
+        task.add_step("Test step", |_ctx| async { Ok(TaskStepStatusOk::Success) });
 
         task.init();
         assert_eq!(task.status, Status::Scheduled);
 
         // One run drives Scheduled -> Executed.
-        task.run_and_notify().await;
+        task.run_and_notify(0).await;
         assert_eq!(task.status, Status::Executed);
 
         // With the single repeat spent, rescheduling retires the task.
@@ -1250,7 +1392,7 @@ mod test {
         let (tx, rx) = mpsc::channel(1);
         let mut task = Task::new("* * * * * * *", Some("Loop"), Some(1), Utc).unwrap();
         task.set_id(3);
-        task.add_step_default(|| async { Ok(Success) });
+        task.add_step_default(|_ctx| async { Ok(Success) });
         task.set_receiver(rx);
 
         let shared = Arc::new(TaskShared::new(DEFAULT_HISTORY_LIMIT));
@@ -1286,7 +1428,7 @@ mod test {
 
         // Add steps that increment counters
         let c1 = counter1.clone();
-        task.add_step("Step 1", move || {
+        task.add_step("Step 1", move |_ctx| {
             let c1 = c1.clone();
             async move {
                 *c1.lock().unwrap() += 1;
@@ -1295,7 +1437,7 @@ mod test {
         });
 
         let c2 = counter2.clone();
-        task.add_step("Step 2", move || {
+        task.add_step("Step 2", move |_ctx| {
             let c2 = c2.clone();
             async move {
                 *c2.lock().unwrap() += 1;
@@ -1304,7 +1446,7 @@ mod test {
         });
 
         let c3 = counter3.clone();
-        task.add_step("Step 3", move || {
+        task.add_step("Step 3", move |_ctx| {
             let c3 = c3.clone();
             async move {
                 *c3.lock().unwrap() += 1;
@@ -1314,7 +1456,7 @@ mod test {
 
         // Initialize and run
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
 
         // Verify all steps executed
         assert_eq!(*counter1.lock().unwrap(), 1);
@@ -1337,7 +1479,7 @@ mod test {
 
         // First step succeeds
         let counter = execution_counter.clone();
-        task.add_step("Step 1", move || {
+        task.add_step("Step 1", move |_ctx| {
             let counter = counter.clone();
             async move {
                 counter.lock().unwrap().push(1);
@@ -1347,7 +1489,7 @@ mod test {
 
         // Second step fails
         let counter = execution_counter.clone();
-        task.add_step("Step 2", move || {
+        task.add_step("Step 2", move |_ctx| {
             let counter = counter.clone();
             async move {
                 counter.lock().unwrap().push(2);
@@ -1357,7 +1499,7 @@ mod test {
 
         // Third step should not execute due to previous failure
         let counter = execution_counter.clone();
-        task.add_step("Step 3", move || {
+        task.add_step("Step 3", move |_ctx| {
             let counter = counter.clone();
             async move {
                 counter.lock().unwrap().push(3);
@@ -1367,7 +1509,7 @@ mod test {
 
         // Initialize and run
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
 
         // Verify only steps 1 and 2 executed
         assert_eq!(*execution_counter.lock().unwrap(), vec![1, 2]);
@@ -1380,13 +1522,13 @@ mod test {
     async fn test_force_removal() {
         // Create a task with a step that forces removal
         let mut task = Task::new("* * * * * * *", Some("Force removal"), None, Local).unwrap();
-        task.add_step("Failing step", || async {
+        task.add_step("Failing step", |_ctx| async {
             Err(TaskStepStatusErr::ErrorDelete)
         });
 
         // Initialize and run
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
 
         // Verify task is marked for force removal
         assert_eq!(task.status, Status::ForceRemoved);
@@ -1403,7 +1545,7 @@ mod test {
 
         // Initialize and run
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
 
         // Verify task is marked as Executed even with no steps
         assert_eq!(task.status, Status::Executed);
@@ -1419,7 +1561,7 @@ mod test {
         let flag = ran.clone();
 
         let mut task = Task::new("* * * * * * *", Some("Async step"), Some(1), Utc).unwrap();
-        task.add_step("Awaits", move || {
+        task.add_step("Awaits", move |_ctx| {
             let flag = flag.clone();
             async move {
                 // Yield to the runtime to prove the future is actually polled/awaited.
@@ -1430,7 +1572,7 @@ mod test {
         });
 
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert!(ran.load(Ordering::SeqCst), "async step body must run");
         assert_eq!(task.status, Status::Executed);
     }
@@ -1439,10 +1581,10 @@ mod test {
     #[tokio::test]
     async fn test_repeat_zero_does_not_underflow() {
         let mut task = Task::new("* * * * * * *", Some("Zero repeats"), Some(0), Utc).unwrap();
-        task.add_step_default(|| async { Ok(Success) });
+        task.add_step_default(|_ctx| async { Ok(Success) });
         task.init();
         // Would panic with an integer underflow before the `saturating_sub` fix.
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.repeats, Some(0));
         // With no repeats left, the task is retired on reschedule.
         assert!(task.reschedule().is_ok());
@@ -1454,14 +1596,14 @@ mod test {
     async fn test_step_timeout_marks_failed() {
         let mut task = Task::new("* * * * * * *", Some("Timeout"), None, Utc).unwrap();
         task.timeout = Some(Duration::from_millis(50));
-        task.add_step_default(|| async {
+        task.add_step_default(|_ctx| async {
             // Sleeps far longer than the timeout; the paused clock auto-advances so
             // the timeout fires without a real wall-clock wait.
             tokio::time::sleep(Duration::from_millis(500)).await;
             Ok(Success)
         });
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::Failed);
     }
 
@@ -1476,7 +1618,7 @@ mod test {
 
         let mut task = Task::new("* * * * * * *", Some("Retry ok"), None, Utc).unwrap();
         task.retry_policy = Some(RetryPolicy::fixed(3, Duration::from_millis(10)));
-        task.add_step_default(move || {
+        task.add_step_default(move |_ctx| {
             let c = c.clone();
             async move {
                 // Fail the first two attempts, succeed on the third.
@@ -1488,7 +1630,7 @@ mod test {
             }
         });
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::Executed);
         assert_eq!(calls.load(Ordering::SeqCst), 3);
     }
@@ -1504,7 +1646,7 @@ mod test {
 
         let mut task = Task::new("* * * * * * *", Some("Retry fail"), None, Utc).unwrap();
         task.retry_policy = Some(RetryPolicy::fixed(2, Duration::from_millis(10)));
-        task.add_step_default(move || {
+        task.add_step_default(move |_ctx| {
             let c = c.clone();
             async move {
                 c.fetch_add(1, Ordering::SeqCst);
@@ -1512,7 +1654,7 @@ mod test {
             }
         });
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::Failed);
         // 1 initial attempt + 2 retries.
         assert_eq!(calls.load(Ordering::SeqCst), 3);
@@ -1529,7 +1671,7 @@ mod test {
 
         let mut task = Task::new("* * * * * * *", Some("Delete"), None, Utc).unwrap();
         task.retry_policy = Some(RetryPolicy::fixed(5, Duration::from_millis(10)));
-        task.add_step_default(move || {
+        task.add_step_default(move |_ctx| {
             let c = c.clone();
             async move {
                 c.fetch_add(1, Ordering::SeqCst);
@@ -1537,7 +1679,7 @@ mod test {
             }
         });
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::ForceRemoved);
         // Called exactly once — no retries.
         assert_eq!(calls.load(Ordering::SeqCst), 1);
@@ -1555,7 +1697,7 @@ mod test {
         let mut task = Task::new("* * * * * * *", Some("Timeout retry"), None, Utc).unwrap();
         task.timeout = Some(Duration::from_millis(50));
         task.retry_policy = Some(RetryPolicy::fixed(2, Duration::from_millis(0)));
-        task.add_step_default(move || {
+        task.add_step_default(move |_ctx| {
             let c = c.clone();
             async move {
                 // First attempt hangs past the timeout; subsequent attempts return quickly.
@@ -1566,7 +1708,7 @@ mod test {
             }
         });
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.status, Status::Executed);
         assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
@@ -1582,7 +1724,7 @@ mod test {
         let finish = Arc::new(AtomicUsize::new(0));
 
         let mut task = Task::new("* * * * * * *", Some("Callbacks"), Some(1), Utc).unwrap();
-        task.add_step_default(|| async { Ok(Success) });
+        task.add_step_default(|_ctx| async { Ok(Success) });
 
         let s = success.clone();
         task.on_success = Some(boxed_callback(move || {
@@ -1611,7 +1753,7 @@ mod test {
 
         // A run fires on_success; the follow-up reschedule retires the task (repeat 1)
         // and fires on_finish exactly once.
-        task.run_and_notify().await;
+        task.run_and_notify(0).await;
         task.reschedule_and_notify().await;
 
         assert_eq!(success.load(Ordering::SeqCst), 1);
@@ -1629,7 +1771,7 @@ mod test {
         let finish = Arc::new(AtomicUsize::new(0));
 
         let mut task = Task::new("* * * * * * *", Some("Callbacks delete"), None, Utc).unwrap();
-        task.add_step_default(|| async { Err(ErrorDelete) });
+        task.add_step_default(|_ctx| async { Err(ErrorDelete) });
 
         let f = failure.clone();
         task.on_failure = Some(boxed_callback(move || {
@@ -1650,7 +1792,7 @@ mod test {
         task.init();
 
         // ForceRemoved is terminal, so run_and_notify fires both on_failure and on_finish.
-        task.run_and_notify().await;
+        task.run_and_notify(0).await;
 
         assert_eq!(failure.load(Ordering::SeqCst), 1);
         assert_eq!(finish.load(Ordering::SeqCst), 1);
@@ -1660,9 +1802,9 @@ mod test {
     #[tokio::test]
     async fn test_step_states_track_outcomes() {
         let mut task = Task::new("* * * * * * *", Some("Steps"), Some(1), Utc).unwrap();
-        task.add_step("ok", || async { Ok(Success) });
-        task.add_step("boom", || async { Err(Error) });
-        task.add_step("never", || async { Ok(Success) });
+        task.add_step("ok", |_ctx| async { Ok(Success) });
+        task.add_step("boom", |_ctx| async { Err(Error) });
+        task.add_step("never", |_ctx| async { Ok(Success) });
         task.set_id(0);
         task.init();
 
@@ -1674,7 +1816,7 @@ mod test {
             .all(|s| s.status == StepStatus::Pending));
         assert_eq!(task.step_states[0].description.as_deref(), Some("ok"));
 
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.step_states[0].status, StepStatus::Succeeded);
         assert_eq!(task.step_states[1].status, StepStatus::Failed);
         assert_eq!(task.step_states[2].status, StepStatus::Skipped);
@@ -1685,9 +1827,9 @@ mod test {
     #[tokio::test]
     async fn test_run_outcome_had_errors() {
         let mut task = Task::new("* * * * * * *", None, Some(1), Utc).unwrap();
-        task.add_step_default(|| async { Ok(TaskStepStatusOk::HadErrors) });
+        task.add_step_default(|_ctx| async { Ok(TaskStepStatusOk::HadErrors) });
         task.init();
-        assert!(task.run_task().await.is_ok());
+        assert!(task.run_task(0).await.is_ok());
         assert_eq!(task.step_states[0].status, StepStatus::HadErrors);
         assert_eq!(task.run_outcome(), RunOutcome::HadErrors);
     }
@@ -1698,7 +1840,7 @@ mod test {
         let mut task = Task::new("* * * * * * *", Some("Hist"), None, Utc).unwrap();
         task.set_id(0);
         task.set_history_limit(2);
-        task.add_step_default(|| async { Ok(Success) });
+        task.add_step_default(|_ctx| async { Ok(Success) });
         task.init();
 
         let shared = TaskShared::new(task.history_limit);
@@ -1728,7 +1870,7 @@ mod test {
     async fn test_history_limit_zero_disables_history() {
         let mut task = Task::new("* * * * * * *", None, None, Utc).unwrap();
         task.set_history_limit(0);
-        task.add_step_default(|| async { Ok(Success) });
+        task.add_step_default(|_ctx| async { Ok(Success) });
         task.init();
 
         let shared = TaskShared::new(task.history_limit);
@@ -1751,11 +1893,11 @@ mod test {
         let mut task = Task::new("* * * * * * *", None, Some(1), Utc).unwrap();
         task.set_id(0);
         // Step 0 succeeds immediately.
-        task.add_step("first", || async { Ok(Success) });
+        task.add_step("first", |_ctx| async { Ok(Success) });
         // Step 1 signals that it has been reached, then waits for permission to finish.
         let r = ready.clone();
         let p = proceed.clone();
-        task.add_step("second", move || {
+        task.add_step("second", move |_ctx| {
             let r = r.clone();
             let p = p.clone();
             async move {
@@ -1814,5 +1956,128 @@ mod test {
         };
         let json = serde_json::to_string(&record).unwrap();
         assert_eq!(serde_json::from_str::<RunRecord>(&json).unwrap(), record);
+    }
+
+    /// A step's context reports the task id/name, run id, step index and attempt. (0.5.0)
+    #[tokio::test]
+    async fn test_context_reports_identity() {
+        let seen = Arc::new(Mutex::new(
+            Vec::<(usize, Option<String>, usize, usize, u32)>::new(),
+        ));
+        let s = seen.clone();
+        let mut task = Task::new("* * * * * *", None, Some(1), Local).unwrap();
+        task.set_name("ctx-task");
+        task.set_id(7);
+        task.add_step("first", move |ctx| {
+            let s = s.clone();
+            async move {
+                s.lock().unwrap().push((
+                    ctx.task_id(),
+                    ctx.task_name().map(str::to_string),
+                    ctx.run_id(),
+                    ctx.step_index(),
+                    ctx.attempt(),
+                ));
+                Ok(Success)
+            }
+        });
+        task.init();
+        // Run with an explicit run id, as the scheduler would.
+        assert!(task.run_task(42).await.is_ok());
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(
+            seen[0],
+            (7, Some("ctx-task".to_string()), 42, 0, 1),
+            "context should carry task id/name, run id, step index and attempt"
+        );
+    }
+
+    /// The per-run store hands values from one step to a later step within the same run,
+    /// and does not leak into the next run. (0.5.0)
+    #[tokio::test]
+    async fn test_run_store_passes_data_between_steps() {
+        let observed = Arc::new(Mutex::new(Vec::<Option<u32>>::new()));
+        let mut task = Task::new("* * * * * *", None, Some(2), Local).unwrap();
+        task.set_id(0);
+        // First step writes a value keyed by the current run id.
+        task.add_step("produce", |ctx| async move {
+            ctx.run_store().set("value", ctx.run_id() as u32 + 1);
+            Ok(Success)
+        });
+        // Second step reads what the first step wrote.
+        let o = observed.clone();
+        task.add_step("consume", move |ctx| {
+            let o = o.clone();
+            async move {
+                o.lock().unwrap().push(ctx.run_store().get::<u32>("value"));
+                Ok(Success)
+            }
+        });
+        task.init();
+
+        // Two runs with distinct run ids; each run gets a fresh store.
+        assert!(task.run_task(0).await.is_ok());
+        assert!(task.reschedule().is_ok());
+        assert!(task.run_task(1).await.is_ok());
+
+        let observed = observed.lock().unwrap();
+        assert_eq!(
+            *observed,
+            vec![Some(1), Some(2)],
+            "each run's store is fresh and visible to later steps in that run"
+        );
+    }
+
+    /// A blackboard attached to the task is visible to every step through its context and
+    /// persists across runs. (0.5.0)
+    #[tokio::test]
+    async fn test_context_blackboard_persists_across_runs() {
+        let board = Blackboard::new();
+        let mut task = Task::new("* * * * * *", None, Some(3), Local).unwrap();
+        task.set_id(0);
+        task.set_blackboard(board.clone());
+        task.add_step("count", |ctx| async move {
+            let n: u32 = ctx.blackboard().get_or_insert("runs", 0);
+            ctx.blackboard().set("runs", n + 1);
+            Ok(Success)
+        });
+        task.init();
+
+        for run_id in 0..3 {
+            assert!(task.run_task(run_id).await.is_ok());
+            let _ = task.reschedule();
+        }
+
+        // The externally-held blackboard reflects every run.
+        assert_eq!(board.get::<u32>("runs"), Some(3));
+    }
+
+    /// The context's attempt counter increments as a failing step is retried. (0.5.0)
+    #[tokio::test]
+    async fn test_context_attempt_increments_on_retry() {
+        use crate::retry::RetryPolicy;
+        let attempts = Arc::new(Mutex::new(Vec::<u32>::new()));
+        let a = attempts.clone();
+        let mut task = Task::new("* * * * * *", None, Some(1), Local).unwrap();
+        task.set_id(0);
+        // Fail the first two attempts (recording each attempt number), succeed on the third.
+        task.set_retry_policy(RetryPolicy::fixed(2, Duration::from_millis(0)));
+        task.add_step("flaky", move |ctx| {
+            let a = a.clone();
+            async move {
+                a.lock().unwrap().push(ctx.attempt());
+                if ctx.attempt() < 3 {
+                    Err(Error)
+                } else {
+                    Ok(Success)
+                }
+            }
+        });
+        task.init();
+        assert!(task.run_task(0).await.is_ok());
+        assert_eq!(task.status, Status::Executed);
+        assert_eq!(*attempts.lock().unwrap(), vec![1, 2, 3]);
     }
 }


### PR DESCRIPTION
BREAKING: task steps now receive a TaskContext. The step-closure signature changed from FnMut() -> Future to FnMut(TaskContext) -> Future; add a parameter to every step (use |_ctx| to ignore it). Lifecycle callbacks (on_success/on_failure/on_finish) are unchanged.

- Added TaskContext, handed to every step for each attempt: identity (task_id, task_name, run_id, step_index, attempt), a task-level Blackboard (ctx.blackboard()), and a fresh per-run store (ctx.run_store()) for XCom-like step-to-step data flow within a run (B-ergo-2)
- Added TaskBuilder::blackboard(...) to attach a shared task-level blackboard (defaults to a fresh, empty one)
- Added TaskSpawner<T> (via TaskScheduler::spawner) for adding tasks to a running scheduler: spawn() is fire-and-forget, spawn_get_id() awaits the assigned id or a duplicate-name/execution error; requests are drained each scheduler round
- Observable/controllable registry is now populated at add_task time, so a SchedulerHandle can observe and control tasks before run() is called, not only mid-round
- Exported TaskContext and TaskSpawner from the crate root
- Migrated all existing steps, doctests and the 10 bundled examples to the new |_ctx| signature; added examples/context_and_spawner.rs (per-run store handoff, task-level blackboard across runs, runtime task injection)
- Added unit and doctests (96 unit + 49 doctests by default; 98 unit + 49 doctests with --features serde); clippy --all-targets, fmt and cargo doc -D warnings clean
- Updated README (new "Step context and data flow" and "Adding tasks at runtime" sections, 0.4->0.5 migration notes) and lib.rs Highlights
- Bumped version to 0.5.0